### PR TITLE
Moving common functions from core

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,18 +1,10 @@
 {
-  "extends": [
-    "airbnb-base",
-    "prettier"
-  ],
-  "plugins": [
-    "prettier"
-  ],
+  "extends": ["airbnb-base", "prettier"],
+  "plugins": ["prettier"],
   "rules": {
-    "strict": [
-      0,
-      "global"
-    ],
-    "class-methods-use-this": [
-      0
-    ]
+    "strict": [0, "global"],
+    "class-methods-use-this": [0],
+    "no-underscore-dangle": [0],
+    "no-restricted-syntax": [0]
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,13 @@
 'use strict';
 
-const schemas = require('./schemas');
 const validators = require('./validators');
+const ReadFile = require('./read-file');
+const schemas = require('./schemas');
+const stream = require('./stream');
 
 module.exports = {
-    schemas,
     validators,
+    ReadFile,
+    schemas,
+    stream,
 };

--- a/lib/read-file.js
+++ b/lib/read-file.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { isReadableStream } = require('./stream');
+
+const ReadFile = class ReadFile {
+    constructor({
+        etag = '',
+    } = {}) {
+        this._stream = undefined;
+        this._etag = etag;
+    }
+
+    set stream(value) {
+        if (!isReadableStream(value)) throw new Error('Value is not a Readable stream');
+        this._stream = value;
+    }
+
+    get stream() {
+        return this._stream;
+    }
+
+    get etag() {
+        return this._etag;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'ReadFile';
+    }
+}
+module.exports = ReadFile;

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const isStream = (stream) => {
+    return stream !== null && typeof stream === 'object' && typeof stream.pipe === 'function';
+};
+module.exports.isStream = isStream;
+
+const isReadableStream = (stream) => {
+    return isStream(stream) && stream.readable !== false && typeof stream._read === 'function' && typeof stream._readableState === 'object';
+};
+module.exports.isReadableStream = isReadableStream;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "test": "tap",
-    "lint:format": "eslint --fix .",
+    "lint:fix": "eslint --fix .",
     "lint": "eslint ."
   },
   "repository": {

--- a/test/read-file.js
+++ b/test/read-file.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { Readable } = require('stream');
+const { test } = require('tap');
+const ReadFile = require('../lib/read-file');
+
+test('ReadFile() - Object type', (t) => {
+    const obj = new ReadFile();
+    t.equal(Object.prototype.toString.call(obj), '[object ReadFile]', 'should be ReadFile');
+    t.end();
+});
+
+test('ReadFile() - Default property values', (t) => {
+    const obj = new ReadFile();
+    t.equal(obj.stream, undefined, '.stream should be "undefined"');
+    t.equal(obj.etag, '', '.etag should be empty String');
+    t.end();
+});
+
+test('ReadFile() - Set a value on the etag argument on the constructor', (t) => {
+    const obj = new ReadFile({ etag: 'foo' });
+    t.equal(obj.etag, 'foo', '.etag should be value set on constructor');
+    t.end();
+});
+
+test('ReadFile() - Set a Readable stream as value on the .stream property', (t) => {
+    const obj = new ReadFile();
+    obj.stream = new Readable();
+    t.true(obj.stream instanceof Readable, '.stream should be value set on .stream');
+    t.end();
+});
+
+test('ReadFile() - Set a non Readable stream as value on the .stream property', (t) => {
+    t.plan(1);
+    t.throws(() => {
+        const obj = new ReadFile();
+        obj.stream = 'foo';
+    }, /Value is not a Readable stream/, 'Should throw');
+    t.end();
+});


### PR DESCRIPTION
This moves a couple of functions from core to this library. We want to reuse these in ex the Google Cloud Storage sink.