### PR TITLE
Add .mimeType property to ReadFile class

### DIFF
--- a/lib/classes/read-file.js
+++ b/lib/classes/read-file.js
@@ -1,13 +1,19 @@
 'use strict';
 
-const { isReadableStream } = require('./stream');
+const { isReadableStream } = require('../stream');
 
 const ReadFile = class ReadFile {
     constructor({
+        mimeType = '',
         etag = '',
     } = {}) {
+        this._mimeType = mimeType;
         this._stream = undefined;
         this._etag = etag;
+    }
+
+    get mimeType() {
+        return this._mimeType;
     }
 
     set stream(value) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const validators = require('./validators');
-const ReadFile = require('./read-file');
+const ReadFile = require('./classes/read-file');
 const schemas = require('./schemas');
 const stream = require('./stream');
 

--- a/test/classes/read-file.js
+++ b/test/classes/read-file.js
@@ -2,7 +2,7 @@
 
 const { Readable } = require('stream');
 const { test } = require('tap');
-const ReadFile = require('../lib/read-file');
+const ReadFile = require('../../lib/classes/read-file');
 
 test('ReadFile() - Object type', (t) => {
     const obj = new ReadFile();
@@ -12,12 +12,19 @@ test('ReadFile() - Object type', (t) => {
 
 test('ReadFile() - Default property values', (t) => {
     const obj = new ReadFile();
+    t.equal(obj.mimeType, '', '.mimeType should be empty String');
     t.equal(obj.stream, undefined, '.stream should be "undefined"');
     t.equal(obj.etag, '', '.etag should be empty String');
     t.end();
 });
 
-test('ReadFile() - Set a value on the etag argument on the constructor', (t) => {
+test('ReadFile() - Set a value on the "mimeType" argument on the constructor', (t) => {
+    const obj = new ReadFile({ mimeType: 'foo' });
+    t.equal(obj.mimeType, 'foo', '.mimeType should be value set on constructor');
+    t.end();
+});
+
+test('ReadFile() - Set a value on the "etag" argument on the constructor', (t) => {
     const obj = new ReadFile({ etag: 'foo' });
     t.equal(obj.etag, 'foo', '.etag should be value set on constructor');
     t.end();


### PR DESCRIPTION
This ads a `.mimeType` property to the ReadFile class so this info can come from the sinks and not further up in the layers.