### PR TITLE
Provide a Sink Interface

### DIFF
--- a/lib/classes/sink.js
+++ b/lib/classes/sink.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const Sink = class Sink {
+    write() {
+        throw new Error('Method not implemented');
+    }
+
+    read() {
+        throw new Error('Method not implemented');
+    }
+
+    delete() {
+        throw new Error('Method not implemented');
+    }
+
+    exist() {
+        throw new Error('Method not implemented');
+    }
+
+    static validateFilePath(filePath) {
+        if (typeof filePath !== 'string') throw new TypeError('Argument must be a String');
+        if (filePath === '') throw new TypeError('Argument can not be an empty String');
+        return filePath;
+    }
+
+    static validateContentType(contentType) {
+        if (typeof contentType !== 'string') throw new TypeError('Argument must be a String');
+        if (contentType === '') throw new TypeError('Argument can not be an empty String');
+        return contentType;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'Sink';
+    }
+};
+module.exports = Sink;

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,10 +4,12 @@ const validators = require('./validators');
 const ReadFile = require('./classes/read-file');
 const schemas = require('./schemas');
 const stream = require('./stream');
+const Sink = require('./classes/sink');
 
 module.exports = {
     validators,
     ReadFile,
     schemas,
     stream,
+    Sink,
 };

--- a/test/classes/sink.js
+++ b/test/classes/sink.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const { test } = require('tap');
+const Sink = require('../../lib/classes/sink');
+
+test('Sink() - Object type', (t) => {
+    const obj = new Sink();
+    t.equal(Object.prototype.toString.call(obj), '[object Sink]', 'should be Sink');
+    t.end();
+});
+
+test('Sink() - Call .write() method', (t) => {
+    const obj = new Sink();
+    t.throws(() => {
+        obj.write();
+    }, /Method not implemented/, 'Should throw');
+    t.end();
+});
+
+test('Sink() - Call .read() method', (t) => {
+    const obj = new Sink();
+    t.throws(() => {
+        obj.read();
+    }, /Method not implemented/, 'Should throw');
+    t.end();
+});
+
+test('Sink() - Call .delete() method', (t) => {
+    const obj = new Sink();
+    t.throws(() => {
+        obj.delete();
+    }, /Method not implemented/, 'Should throw');
+    t.end();
+});
+
+test('Sink() - Call .exist() method', (t) => {
+    const obj = new Sink();
+    t.throws(() => {
+        obj.exist();
+    }, /Method not implemented/, 'Should throw');
+    t.end();
+});
+
+test('Sink() - Call .validateFilePath() with legal value', (t) => {
+    t.equal(Sink.validateFilePath('foo'), 'foo', 'Should return value');
+    t.end();
+});
+
+test('Sink() - Call .validateFilePath() with illegal values', (t) => {
+    t.throws(() => {
+        Sink.validateFilePath();
+        Sink.validateFilePath({});
+        Sink.validateFilePath(300);
+        Sink.validateFilePath(true);
+    }, /Argument must be a String/, 'Should throw');
+    t.end();
+});
+
+test('Sink() - Call .validateFilePath() with empty String value', (t) => {
+    t.throws(() => {
+        Sink.validateFilePath('')
+    }, /Argument can not be an empty String/, 'Should throw');
+    t.end();
+});
+
+test('Sink() - Call .validateContentType() with legal value', (t) => {
+    t.equal(Sink.validateContentType('foo'), 'foo', 'Should return value');
+    t.end();
+});
+
+test('Sink() - Call .validateContentType() with illegal values', (t) => {
+    t.throws(() => {
+        Sink.validateContentType();
+        Sink.validateContentType({});
+        Sink.validateContentType(300);
+        Sink.validateContentType(true);
+    }, /Argument must be a String/, 'Should throw');
+    t.end();
+});
+
+test('Sink() - Call .validateContentType() with empty String value', (t) => {
+    t.throws(() => {
+        Sink.validateContentType('')
+    }, /Argument can not be an empty String/, 'Should throw');
+    t.end();
+});


### PR DESCRIPTION
Loose idea; The sinks is a vital part of Eik and the idea is that anyone should be able to implement a Sink to write and read files from any storage which suite them. Though, internally in Eik we depend on a specific API of the sink for this to work.

This is a small Sink interface which a custom sink should extend and override its method of to make sure the implementation adhere to this specific API. Iow; for a implementor of a sink, she would have to do as follow:

```js
const { Sink } = require('@eik/common');

const CustomSink = class CustomSink extends Sink {
    constructor() {
        super();
    }

    write() { /* Custom code */ }
    read() { /* Custom code */ }
    delete() { /* Custom code */ }
    exist() { /* Custom code */ }
}
```

In `@eik/core` if the Sink does not extend this interface, `@eik/core` will throw. If one of the methods in the interface is not overridden the interface will throw when used in `@eik/core`.

This interface also comes with a couple of static methods the implementor of a Sink can use to validate the arguments of the methods.