### PR TITLE
Add "npm" as valid value to type validators

### DIFF
--- a/lib/validators/index.js
+++ b/lib/validators/index.js
@@ -46,7 +46,7 @@ const alias = value => {
 module.exports.alias = alias;
 
 const type = value => {
-    if (value === 'pkg' || value === 'map') {
+    if (value === 'pkg' || value === 'map' || value === 'npm') {
         return value;
     }
     throw new Error('Parameter "type" is not valid');

--- a/test/validators/index.js
+++ b/test/validators/index.js
@@ -184,6 +184,7 @@ tap.test('.name() - invalid value - semver latest - should throw', t => {
 tap.test('.type() - valid values - should return value', t => {
     t.equal(validators.type('pkg'), 'pkg');
     t.equal(validators.type('map'), 'map');
+    t.equal(validators.type('npm'), 'npm');
     t.end();
 });
 


### PR DESCRIPTION
Adds "npm" to type validator so it can be used as a namespace in URLs.