### PR TITLE
fix: loosen validation

### DIFF
--- a/lib/schemas/eikjson.schema.json
+++ b/lib/schemas/eikjson.schema.json
@@ -23,12 +23,8 @@
       "description": "File mapping definition for the package. Keys represent files or paths to be created on the Eik Server. Values represent paths to local files to be published.",
       "type": "object",
       "minProperties": 1,
-      "propertyNames": {
-        "pattern": "^[\\./a-z_-][\\./a-z0-9_-]*$"
-      },
       "additionalProperties": {
-        "type": "string",
-        "pattern": "^[\\./a-z_-][\\./a-z0-9_-]*$"
+        "type": "string"
       }
     },
     "import-map": {
@@ -40,8 +36,7 @@
           "items": {
             "type": "string",
             "format": "uri"
-          },
-          "minItems": 1
+          }
         }
       ]
     },

--- a/test/schemas/index.js
+++ b/test/schemas/index.js
@@ -130,8 +130,8 @@ test('validate importMap: invalid string', t => {
 });
 
 test('validate importMap: invalid array', t => {
-    const result = validate.importMap([]);
-    t.same(result.value, []);
+    const result = validate.importMap(['']);
+    t.same(result.value, ['']);
     t.equal(result.error.length, 3);
     t.end();
 });


### PR DESCRIPTION
Needed to loosen up the schema to accommodate npm package names and globs in paths