### PR TITLE
Add assert functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,22 @@ This package contains common utilities and schemas
 Importing schemas 
 
 ```js
-const { schemas } = require('@eik/common');
+const { schemas, assert } = require('@eik/common');
 ```
 
 Validating an `eik.json` file
 
 ```js
 const { error, value } = schemas.validate.eikJSON({
+    name: 'my-app',
+    version: '1.0.0',
+    server: 'http://eik-server',
+    files: [],
+});
+
+//or 
+
+assert.eikJSON({
     name: 'my-app',
     version: '1.0.0',
     server: 'http://eik-server',
@@ -31,22 +40,40 @@ Using invididual schema validators
 
 ```js
 const { error, value } = schemas.validate.name('my-app');
+
+// or
+
+assert.name('my-app');
 ```
 
 ##### version
 
 ```js
 const { error, value } = schemas.validate.version('1.0.0');
+
+// or
+
+assert.version('1.0.0');
 ```
 ##### server
 
 ```js
 const { error, value } = schemas.validate.server('http://myeikserver.com');
+
+// or
+
+assert.server('http://myeikserver.com');
 ```
 ##### files
 
 ```js
 const { error, value } = schemas.validate.files({
+    './index.js': '/path/to/file.js'
+});
+
+// or
+
+assert.files({
     './index.js': '/path/to/file.js'
 });
 ```
@@ -60,10 +87,21 @@ const { error, value } = schemas.validate.importMap([
     'http://meserver.com/map1.json',
     'http://meserver.com/map2.json',
 ]);
+
+// or
+
+assert.importMap([
+    'http://meserver.com/map1.json',
+    'http://meserver.com/map2.json',
+]);
 ```
 
 ##### out
 
 ```js
 const { error, value } = schemas.validate.out('./.eik');
+
+// or
+
+assert.out('./.eik');
 ```

--- a/lib/schemas/assert.js
+++ b/lib/schemas/assert.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const {
+    eikJSON,
+    name,
+    version,
+    server,
+    files,
+    importMap,
+    out,
+} = require('./validate');
+
+class ValidationError extends Error {
+    constructor(message, err) {
+        let m = message;
+        if (err && err.message) m += `: ${err.message}`;
+        super(m);
+        this.name = this.constructor.name;
+        Error.captureStackTrace(this, this.constructor);
+    }
+}
+
+const assert = (validate, message) => {
+    return (value) => {
+        const valid = validate(value);
+        if (valid.error) {
+            const errorMessage = valid.error.map(err => err.message).join(',')
+            throw new ValidationError(`${message}: ${errorMessage}`);
+        }
+    }
+}
+
+module.exports.eikJSON = assert(eikJSON, 'Invalid eik.json schema');
+module.exports.name = assert(name, 'Parameter "name" is not valid');
+module.exports.version = assert(version, 'Parameter "version" is not valid');
+module.exports.server = assert(server, 'Parameter "server" is not valid');
+module.exports.files = assert(files, 'Parameter "files" is not valid');
+module.exports.importMap = assert(importMap, 'Parameter "import-map" is not valid');
+module.exports.out = assert(out, 'Parameter "out" is not valid');

--- a/lib/schemas/index.js
+++ b/lib/schemas/index.js
@@ -2,6 +2,8 @@
 
 const schema = require('./eikjson.schema.json');
 const validate = require('./validate');
+const assert = require('./assert');
 
 module.exports.schema = schema;
 module.exports.validate = validate;
+module.exports.assert = assert;

--- a/test/schemas/assert.js
+++ b/test/schemas/assert.js
@@ -1,0 +1,148 @@
+const { test } = require('tap');
+const { assert } = require('../../lib/schemas/index');
+
+test('assert basic eik JSON file', t => {
+    t.notThrow(() => {
+        assert.eikJSON({
+            name: 'my-app-name',
+            version: '1.0.0',
+            server: 'http://localhost:4001',
+            files: {
+                'index.js': './assets/scripts.js',
+                'index.css': './assets/styles.css',
+            },
+        });
+    });
+    t.end();
+});
+
+test('assert asset manifest - all props invalid', t => {
+    t.throws(() => {
+        assert.eikJSON({
+            name: '',
+        });
+    });
+    t.end();
+});
+
+test('assert name: empty string', t => {
+    t.throws(() => {
+        assert.name('');
+    });
+    t.end();
+});
+
+test('assert name: valid', t => {
+    t.notThrow(() => {
+        assert.name('@finn-no/my-app');
+    });
+    t.end();
+});
+
+test('assert name: invalid by assert-npm-package-name module', t => {
+    t.throws(() => {
+        assert.name('@finn-no/my-app~');
+    });
+    t.end();
+});
+
+test('assert version: empty string', t => {
+    t.throws(() => {
+        assert.version('');
+    });
+    t.end();
+});
+
+test('assert version: valid', t => {
+    t.notThrow(() => {
+        assert.version('1.0.0');
+    });
+    t.end();
+});
+
+test('assert version: invalid by node-semver module', t => {
+    t.throws(() => {
+        assert.version('1.0');
+    });
+    t.end();
+});
+
+test('assert server: valid', t => {
+    t.notThrow(() => {
+        assert.server('http://localhost:4000');
+    });
+    t.end();
+});
+
+test('assert server: invalid', t => {
+    t.throws(() => {
+        assert.server('localhost');
+    });
+    t.end();
+});
+
+test('assert files: valid', t => {
+    t.notThrow(() => {
+        assert.files({ 'index.js': '/path/to/file.js' });
+    });
+    t.end();
+});
+
+test('assert files: invalid', t => {
+    t.throws(() => {
+        assert.files({ asd: 1 });
+    });
+    t.end();
+});
+
+test('assert files: invalid', t => {
+    t.throws(() => {
+        assert.files({});
+    });
+    t.end();
+});
+
+test('assert importMap: valid string', t => {
+    t.notThrow(() => {
+        assert.importMap('http://myimportmap/file.json');
+    });
+    t.end();
+});
+
+test('assert importMap: valid array', t => {
+    t.notThrow(() => {
+        assert.importMap([
+            'http://myimportmap/file1.json',
+            'http://myimportmap/file2.json',
+        ]);
+    });
+    t.end();
+});
+
+test('assert importMap: invalid string', t => {
+    t.throws(() => {
+        assert.importMap('');
+    });
+    t.end();
+});
+
+test('assert importMap: invalid array', t => {
+    t.throws(() => {
+        assert.importMap(['']);
+    });
+    t.end();
+});
+
+test('assert out: valid', t => {
+    t.notThrow(() => {
+        assert.out('./.eik');
+    });
+    t.end();
+});
+
+test('assert out: invalid', t => {
+    t.throws(() => {
+        assert.out('');
+    });
+    t.end();
+});


### PR DESCRIPTION
Due to the way ajv validation works, I ended up having to check errors and throw repeatedly in many places. I though it would be much nicer to have an “asserts” function for each validation so that you can just call Eg. `asserts.name(“@finn-no/thing”)` which will throw on error with a nice error message. 