### PR TITLE
Ensure map property for config is always an array

### DIFF
--- a/lib/classes/eik-config.js
+++ b/lib/classes/eik-config.js
@@ -13,6 +13,7 @@ module.exports = class EikConfig {
 
         this[_tokens] = new Map(tokens);
         this.cwd = configRootDir;
+        this.map = [].concat(configHash['import-map'] || [])
     }
 
     get name() {
@@ -21,10 +22,6 @@ module.exports = class EikConfig {
 
     get version() {
         return this[_config].version;
-    }
-
-    get map() {
-        return this[_config]['import-map'] || [];
     }
 
     get server() {

--- a/test/classes/eik-config.test.js
+++ b/test/classes/eik-config.test.js
@@ -7,12 +7,19 @@ test('basic config properties', (t) => {
         name: 'pizza',
         files: 'secret receipe',
         version: 'deep dish',
-        'import-map': 'cheese from italy',
     });
     t.equal(config.name, 'pizza');
     t.equal(config.files, 'secret receipe');
     t.equal(config.version, 'deep dish');
-    t.equal(config.map, 'cheese from italy');
+    t.end();
+});
+
+test('map property', (t) => {
+    let config = new EikConfig({ 'import-map': 'cheese from italy' });
+    t.deepEqual(config.map, ['cheese from italy']);
+
+    config = new EikConfig({ 'import-map': ['gouda', 'mozzarella'] });
+    t.deepEqual(config.map, ['gouda', 'mozzarella']);
     t.end();
 });
 

--- a/test/helpers/config-store.test.js
+++ b/test/helpers/config-store.test.js
@@ -17,7 +17,7 @@ test('loads from package.json', (t) => {
     t.equal(config.name, 'magarita');
     t.equal(config.version, 'tomato');
     t.equal(config.notIncluded, undefined);
-    t.equal(config.map, 'deep dish');
+    t.deepEqual(config.map, ['deep dish']);
     t.end();
 });
 


### PR DESCRIPTION
Why: This is what is allowed according to the schema.