### PR TITLE
fix: remove singletons in packageURL and localAssets

### DIFF
--- a/lib/helpers/local-assets.js
+++ b/lib/helpers/local-assets.js
@@ -5,8 +5,6 @@ const { join, extname, basename } = require('path');
 const fs = require('fs');
 const configStore = require("./config-store")
 
-let eik;
-
 /**
  * Sets up asset routes for local development. Mounted paths match those on Eik server and values are read from projects eik.json file.
  * 
@@ -20,7 +18,7 @@ async function localAssets(
     assert(app.decorateReply || app.name === 'app', 'App must be an Express or Fastify app instance');
     assert(typeof rootEikDirectory === 'string' && rootEikDirectory, 'Path to folder for eik config must be provided and must be of type string');
     // ensure eik.json only loaded 1x
-    if (!eik) eik = configStore.findInDirectory(rootEikDirectory);
+    const eik = configStore.findInDirectory(rootEikDirectory);
 
     (await eik.pathsAndFiles()).forEach(([pathname, filePath]) => {
         const ext = extname(filePath);

--- a/lib/helpers/package-url.js
+++ b/lib/helpers/package-url.js
@@ -1,10 +1,8 @@
 const { join } = require('path');
 const configStore = require('./config-store');
 
-let eik;
-
 async function packageURL(key, { configRootDir = process.cwd() } = {}) {
-    if (!eik) eik = configStore.findInDirectory(configRootDir);
+    const eik = configStore.findInDirectory(configRootDir);
     const mappingList = (await eik.pathsAndFiles()).filter(
         ([, , originalDest]) => originalDest === key,
     );


### PR DESCRIPTION
Silly me, of course this came back to bite me. There are cases where you want to load different eik.json files. With these singletons, this wasn't possible.