### PR TITLE
feat: Add config serializer method

### DIFF
--- a/lib/classes/eik-config.js
+++ b/lib/classes/eik-config.js
@@ -13,7 +13,7 @@ module.exports = class EikConfig {
 
         this[_tokens] = new Map(tokens);
         this.cwd = configRootDir;
-        this.map = [].concat(configHash['import-map'] || [])
+        this.map = [].concat(configHash['import-map'] || []);
     }
 
     get name() {
@@ -42,6 +42,10 @@ module.exports = class EikConfig {
 
     get out() {
         return this[_config].out || '.eik';
+    }
+
+    toJSON() {
+        return { ...this[_config] };
     }
 
     async pathsAndFiles() {

--- a/test/classes/eik-config.test.js
+++ b/test/classes/eik-config.test.js
@@ -66,6 +66,31 @@ test('cwd property', (t) => {
     t.end();
 });
 
+test('toJSON method', (t) => {
+    const config = new EikConfig(
+        {
+            name: 'name',
+            version: 'version',
+            server: 'server',
+            files: {},
+            out: 'out',
+        },
+        [['bakery', 'muffin']],
+        'pizza shop',
+    );
+    t.same(config.toJSON(), {
+        name: 'name',
+        version: 'version',
+        server: 'server',
+        files: {},
+        out: 'out',
+    });
+
+    const configNoOut = new EikConfig({});
+    t.equal(configNoOut.toJSON().out, undefined);
+    t.end();
+});
+
 test('pathsAndFiles returns expected contents', async (t) => {
     const config = new EikConfig(
         {


### PR DESCRIPTION
Why: So that the config data can be copied externally.