### PR TITLE
Add config persistence to config store

### DIFF
--- a/lib/classes/eik-config.js
+++ b/lib/classes/eik-config.js
@@ -24,6 +24,10 @@ module.exports = class EikConfig {
         return this[_config].version;
     }
 
+    set version(newVersion) {
+        this[_config].version = newVersion;
+    }
+
     get server() {
         const configuredServer = this[_config].server;
         if (configuredServer) {

--- a/lib/classes/eik-config.js
+++ b/lib/classes/eik-config.js
@@ -13,7 +13,7 @@ module.exports = class EikConfig {
 
         this[_tokens] = new Map(tokens);
         this.cwd = configRootDir;
-        this.map = [].concat(configHash['import-map'] || [])
+        this.map = [].concat(configHash['import-map'] || []);
     }
 
     get name() {

--- a/lib/classes/eik-config.js
+++ b/lib/classes/eik-config.js
@@ -44,6 +44,10 @@ module.exports = class EikConfig {
         return this[_config].out || '.eik';
     }
 
+    toJSON() {
+        return { ...this[_config] };
+    }
+
     async pathsAndFiles() {
         const resolvedFiles = await Promise.all(
             Object.entries(this.files).map(([pathname, file]) =>

--- a/lib/helpers/config-store.js
+++ b/lib/helpers/config-store.js
@@ -1,4 +1,4 @@
-const { readFileSync } = require('fs');
+const { readFileSync, writeFileSync } = require('fs');
 const { join } = require('path');
 const homedir = require('os').homedir();
 
@@ -48,5 +48,9 @@ module.exports = {
         }
         const eikrc = loadJSONFromDisk(join(homedir, '.eikrc')) || {};
         return new EikConfig(assets, eikrc.tokens, configRootDir);
+    },
+    persistToDisk(config) {
+        const dest = join(config.cwd, 'eik.json');
+        writeFileSync(dest, JSON.stringify(config, null, 2));
     },
 };

--- a/test/classes/eik-config.test.js
+++ b/test/classes/eik-config.test.js
@@ -66,6 +66,13 @@ test('cwd property', (t) => {
     t.end();
 });
 
+test('setting the version', (t) => {
+    const config = new EikConfig({});
+    config.version = 'big cheese';
+    t.equal(config.version, 'big cheese');
+    t.end();
+});
+
 test('pathsAndFiles returns expected contents', async (t) => {
     const config = new EikConfig(
         {

--- a/test/helpers/config-store.test.js
+++ b/test/helpers/config-store.test.js
@@ -1,9 +1,13 @@
 const { test } = require('tap');
 const fs = require('fs').promises;
-const path = require('path');
+const { join } = require('path');
 const os = require('os');
 const configStore = require('../../lib/helpers/config-store');
 const EikConfig = require('../../lib/classes/eik-config');
+
+function mkdirTempDir() {
+    return fs.mkdtemp(join(os.tmpdir(), 'eik-config'));
+}
 
 test('loads from package.json', (t) => {
     const config = configStore.findInDirectory('pizza dir', (path) => {
@@ -152,7 +156,3 @@ test('handles no path being provided', async (t) => {
     }
     t.end();
 });
-
-function mkdirTempDir() {
-    return fs.mkdtemp(path.join(os.tmpdir(), 'eik-config'));
-}

--- a/test/helpers/config-store.test.js
+++ b/test/helpers/config-store.test.js
@@ -35,6 +35,7 @@ test('loads from eik.json', (t) => {
 });
 
 test('package.json and eik.json not being present', (t) => {
+    t.plan(1);
     try {
         configStore.findInDirectory('pizza dir', () => null);
     } catch (e) {
@@ -89,6 +90,7 @@ test('tokens are present', (t) => {
 });
 
 test('invalid json error', (t) => {
+    t.plan(1);
     const jsonReaderStub = (path) => {
         if (path.includes('.json')) JSON.parse('not json');
         return {};
@@ -103,6 +105,7 @@ test('invalid json error', (t) => {
 });
 
 test('no configuration present', (t) => {
+    t.plan(1);
     try {
         configStore.findInDirectory('pizza dir', () => {});
     } catch (e) {
@@ -115,13 +118,7 @@ test('no configuration present', (t) => {
 });
 
 test('reading without stubbed json', (t) => {
-    try {
-        configStore.findInDirectory(__dirname);
-    } catch (e) {
-        t.equal(
-            e.message,
-            `No package.json or eik.json file found in: '${__dirname}'`,
-        );
-    }
+    const config = configStore.findInDirectory(__dirname);
+    t.equal(config.name, 'my-app');
     t.end();
 });


### PR DESCRIPTION
This means that consumers of configuration that wish to bump the version of the eik pkg can now do so without worrying about how to persist the config correctly.