### PR TITLE
feat: add "type" field to JSON Schema, validation and asserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ const { error, value } = schemas.validate.version('1.0.0');
 
 assert.version('1.0.0');
 ```
+
+##### type
+
+```js
+const { error, value } = schemas.validate.type('package');
+
+// or
+
+assert.type('package');
+```
+
 ##### server
 
 ```js

--- a/lib/schemas/assert.js
+++ b/lib/schemas/assert.js
@@ -15,7 +15,13 @@ const ValidationError = require('./validation-error');
 const assert = (validate, message) => value => {
         const valid = validate(value);
         if (valid.error) {
-            const errorMessage = valid.error.map(err => err.message).join(',');
+            const errorMessage = valid.error.map(err => {
+                let msg = err.message;
+                if (err.params && err.params.allowedValues) {
+                    msg += ` ("${err.params.allowedValues.join('", ')}")`;
+                }
+                return msg;
+            }).join(',');
             throw new ValidationError(`${message}: ${errorMessage}`);
         }
     };

--- a/lib/schemas/assert.js
+++ b/lib/schemas/assert.js
@@ -4,6 +4,7 @@ const {
     eikJSON,
     name,
     version,
+    type,
     server,
     files,
     importMap,
@@ -22,6 +23,7 @@ const assert = (validate, message) => value => {
 module.exports = {
     eikJSON: assert(eikJSON, 'Invalid eik.json schema'),
     name: assert(name, 'Parameter "name" is not valid'),
+    type: assert(type, 'Parameter "type" is not valid'),
     version: assert(version, 'Parameter "version" is not valid'),
     server: assert(server, 'Parameter "server" is not valid'),
     files: assert(files, 'Parameter "files" is not valid'),

--- a/lib/schemas/eikjson.schema.json
+++ b/lib/schemas/eikjson.schema.json
@@ -20,7 +20,7 @@
       "minLength": 1
     },
     "type": {
-      "description": "The type of the Eik package. Must be one of 'package', 'npm' or 'map'",
+      "description": "The type of the Eik package. Must be one of 'package', 'npm' or 'map'. Setting this value changes the URL publish namespace between '/pkg' (default), '/npm' and '/map', use 'npm' when publishing NPM packages. Use 'map' when publishing import maps.",
       "type": "string",
       "enum": ["package", "npm", "map"],
       "default": "package"

--- a/lib/schemas/eikjson.schema.json
+++ b/lib/schemas/eikjson.schema.json
@@ -19,6 +19,12 @@
       "type": "string",
       "minLength": 1
     },
+    "type": {
+      "description": "The type of the Eik package. Must be one of 'package', 'npm' or 'map'",
+      "type": "string",
+      "enum": ["package", "npm", "map"],
+      "default": "package"
+    },
     "files": {
       "description": "File mapping definition for the package. Keys represent files or paths to be created on the Eik Server. Values represent paths to local files to be published.",
       "type": "object",

--- a/lib/schemas/validate.js
+++ b/lib/schemas/validate.js
@@ -77,6 +77,7 @@ const createVersionValidator = (jsonSchemaValidator) => (value) => {
 
 const name = createNameValidator(createValidator(eikJSONSchema.properties.name));
 const version = createVersionValidator(createValidator(eikJSONSchema.properties.version));
+const type = createValidator(eikJSONSchema.properties.type);
 const server = createValidator(eikJSONSchema.properties.server);
 const files = createValidator(eikJSONSchema.properties.files);
 const importMap = createValidator(eikJSONSchema.properties['import-map']);
@@ -85,6 +86,7 @@ const out = createValidator(eikJSONSchema.properties.out);
 module.exports.eikJSON = eikJSON;
 module.exports.name = name;
 module.exports.version = version;
+module.exports.type = type;
 module.exports.server = server;
 module.exports.files = files;
 module.exports.importMap = importMap;

--- a/test/schemas/assert.js
+++ b/test/schemas/assert.js
@@ -61,9 +61,12 @@ test('assert version: valid', t => {
 });
 
 test('assert type: invalid', t => {
-    t.throws(() => {
+    t.plan(1);
+    try {
         assert.type('foo');
-    });
+    } catch (err) {
+        t.equal(err.message, 'Parameter "type" is not valid: should be equal to one of the allowed values ("package", npm", map")');
+    }
     t.end();
 });
 

--- a/test/schemas/assert.js
+++ b/test/schemas/assert.js
@@ -60,6 +60,34 @@ test('assert version: valid', t => {
     t.end();
 });
 
+test('assert type: invalid', t => {
+    t.throws(() => {
+        assert.type('foo');
+    });
+    t.end();
+});
+
+test('assert type: valid - package', t => {
+    t.notThrow(() => {
+        assert.type('package');
+    });
+    t.end();
+});
+
+test('assert type: valid - npm', t => {
+    t.notThrow(() => {
+        assert.type('npm');
+    });
+    t.end();
+});
+
+test('assert type: valid - map', t => {
+    t.notThrow(() => {
+        assert.type('map');
+    });
+    t.end();
+});
+
 test('assert version: invalid by node-semver module', t => {
     t.throws(() => {
         assert.version('1.0');

--- a/test/schemas/index.js
+++ b/test/schemas/index.js
@@ -11,6 +11,7 @@ test('validate basic eik JSON file', t => {
             'index.css': './assets/styles.css',
         },
     });
+    t.equal(result.value.type, 'package');
     t.equal(result.error, false);
     t.end();
 });
@@ -20,7 +21,7 @@ test('validate asset manifest - all props invalid', t => {
         name: '',
     });
 
-    t.same(result.value, { name: '' });
+    t.same(result.value, { name: '', type: 'package' });
     t.equal(result.error[0].message, `should have required property 'server'`);
     t.end();
 });
@@ -56,6 +57,32 @@ test('validate version: empty string', t => {
 test('validate version: valid', t => {
     const result = validate.version('1.0.0');
     t.equal(result.value, '1.0.0');
+    t.equal(result.error, false);
+    t.end();
+});
+
+test('validate type: empty string', t => {
+    const result = validate.type('');
+    t.equal(result.value, '');
+    t.equal(result.error.length, 1);
+    t.end();
+});
+
+test('validate type: valid - package', t => {
+    const result = validate.type('package');
+    t.equal(result.value, 'package');
+    t.equal(result.error, false);
+    t.end();
+});
+test('validate type: valid - npm', t => {
+    const result = validate.type('npm');
+    t.equal(result.value, 'npm');
+    t.equal(result.error, false);
+    t.end();
+});
+test('validate type: valid - map', t => {
+    const result = validate.type('map');
+    t.equal(result.value, 'map');
     t.equal(result.error, false);
     t.end();
 });

--- a/test/schemas/index.js
+++ b/test/schemas/index.js
@@ -65,6 +65,7 @@ test('validate type: empty string', t => {
     const result = validate.type('');
     t.equal(result.value, '');
     t.equal(result.error.length, 1);
+    t.equal(result.error[0].message, 'should be equal to one of the allowed values');
     t.end();
 });
 


### PR DESCRIPTION
Begins work on https://github.com/eik-lib/issues/issues/1 by adding a `type` field to the schema