### PR TITLE
feat!: add type field to eik config schema

### DIFF
--- a/lib/classes/eik-config.js
+++ b/lib/classes/eik-config.js
@@ -10,10 +10,7 @@ const _tokens = Symbol('tokens');
 
 module.exports = class EikConfig {
     constructor(configHash, tokens, configRootDir) {
-        assert.eikJSON(configHash);
-
         this[_config] = configHash;
-
         this[_tokens] = new Map(tokens);
         this.cwd = configRootDir;
         this.map = [].concat(configHash['import-map'] || []);
@@ -59,6 +56,10 @@ module.exports = class EikConfig {
 
     toJSON() {
         return { ...this[_config] };
+    }
+
+    validate() {
+        assert.eikJSON(this[_config]);
     }
 
     async pathsAndFiles() {

--- a/lib/classes/eik-config.js
+++ b/lib/classes/eik-config.js
@@ -3,12 +3,15 @@ const path = require('path');
 const glob = promisify(require('glob'));
 const NoFilesMatchedError = require('./no-files-matched-error');
 const SingleDestMultipleSourcesError = require('./single-dest-multiple-source-error');
+const { validate, assert } = require('../schemas');
 
 const _config = Symbol('config');
 const _tokens = Symbol('tokens');
 
 module.exports = class EikConfig {
     constructor(configHash, tokens, configRootDir) {
+        assert.eikJSON(configHash);
+
         this[_config] = configHash;
 
         this[_tokens] = new Map(tokens);
@@ -25,7 +28,13 @@ module.exports = class EikConfig {
     }
 
     set version(newVersion) {
+        assert.version(newVersion);
         this[_config].version = newVersion;
+    }
+
+    get type() {
+        const valid = validate.type(this[_config].type);
+        return valid.value;
     }
 
     get server() {

--- a/lib/classes/invalid-config-error.js
+++ b/lib/classes/invalid-config-error.js
@@ -1,0 +1,7 @@
+const CustomError = require('./custom-error');
+
+module.exports = class InvalidConfigError extends CustomError {
+    constructor(msg) {
+        super(`Eik config object was invalid: '${msg}'`);
+    }
+};

--- a/lib/helpers/config-store.js
+++ b/lib/helpers/config-store.js
@@ -5,6 +5,7 @@ const homedir = require('os').homedir();
 const EikConfig = require('../classes/eik-config');
 const MissingConfigError = require('../classes/missing-config-error');
 const MultipleConfigSourcesError = require('../classes/multiple-config-sources-error');
+const InvalidConfigError = require('../classes/invalid-config-error');
 
 function readJSONFromDisk(path) {
     let fileData;
@@ -48,11 +49,19 @@ module.exports = {
         }
         const eikrc = loadJSONFromDisk(join(homedir, '.eikrc')) || {};
         const config = new EikConfig(assets, eikrc.tokens, configRootDir);
-        config.validate();
+        try {
+            config.validate();
+        } catch(err) {
+            throw new InvalidConfigError(`config.findInDirectory operation failed: ${err.message}`);
+        }
         return config;
     },
     persistToDisk(config) {
-        config.validate();
+        try {
+            config.validate();
+        } catch(err) {
+            throw new InvalidConfigError(`config.persistToDisk operation failed: ${err.message}`);
+        }
         const dest = join(config.cwd, 'eik.json');
         writeFileSync(dest, JSON.stringify(config, null, 2));
     },

--- a/lib/helpers/config-store.js
+++ b/lib/helpers/config-store.js
@@ -47,9 +47,12 @@ module.exports = {
             throw new MissingConfigError(configRootDir);
         }
         const eikrc = loadJSONFromDisk(join(homedir, '.eikrc')) || {};
-        return new EikConfig(assets, eikrc.tokens, configRootDir);
+        const config = new EikConfig(assets, eikrc.tokens, configRootDir);
+        config.validate();
+        return config;
     },
     persistToDisk(config) {
+        config.validate();
         const dest = join(config.cwd, 'eik.json');
         writeFileSync(dest, JSON.stringify(config, null, 2));
     },

--- a/lib/schemas/validate.js
+++ b/lib/schemas/validate.js
@@ -37,16 +37,7 @@ const createNameValidator = (jsonSchemaValidator) => (value) => {
                 dataPath: '.name',
                 schemaPath: '',
                 params: [],
-                message: 'should be valid for new packages',
-            });
-        }
-        if (!pkvalid.validForOldPackages) {
-            errors.push({
-                keyword: 'validForOldPackages',
-                dataPath: '.name',
-                schemaPath: '',
-                params: [],
-                message: 'should be valid for old packages',
+                message: 'should be valid package name',
             });
         }
         if (errors.length) {

--- a/lib/schemas/validate.js
+++ b/lib/schemas/validate.js
@@ -15,9 +15,10 @@ const createValidator = (schema, ajvOptions) => {
         ...schema,
     });
 
-    return data => {
-        const valid = validate(data);
-        return { value: data, error: !valid && validate.errors };
+    return (data) => {
+        const cloned = JSON.parse(JSON.stringify(data));
+        const valid = validate(cloned);
+        return { value: cloned, error: !valid && validate.errors };
     };
 };
 
@@ -26,57 +27,61 @@ const eikJSON = createValidator(eikJSONSchema, {
     useDefaults: true,
 });
 const createNameValidator = (jsonSchemaValidator) => (value) => {
-        const result = jsonSchemaValidator(value);
-        if (!result.error) {
-            const pkvalid = npmPkg(value);
-            const errors = [];
-            if (!pkvalid.validForNewPackages) {
-                errors.push({
-                    keyword: 'validForNewPackages',
-                    dataPath: '.name',
-                    schemaPath: '',
-                    params: [],
-                    message: 'should be valid for new packages'
-                });
-            }
-            if (!pkvalid.validForOldPackages) {
-                errors.push({
-                    keyword: 'validForOldPackages',
-                    dataPath: '.name',
-                    schemaPath: '',
-                    params: [],
-                    message: 'should be valid for old packages'
-                });
-            }
-            if (errors.length) {
-                result.error = errors;
-            }
+    const result = jsonSchemaValidator(value);
+    if (!result.error) {
+        const pkvalid = npmPkg(value);
+        const errors = [];
+        if (!pkvalid.validForNewPackages) {
+            errors.push({
+                keyword: 'validForNewPackages',
+                dataPath: '.name',
+                schemaPath: '',
+                params: [],
+                message: 'should be valid for new packages',
+            });
         }
-        return result;
+        if (!pkvalid.validForOldPackages) {
+            errors.push({
+                keyword: 'validForOldPackages',
+                dataPath: '.name',
+                schemaPath: '',
+                params: [],
+                message: 'should be valid for old packages',
+            });
+        }
+        if (errors.length) {
+            result.error = errors;
+        }
     }
+    return result;
+};
 const createVersionValidator = (jsonSchemaValidator) => (value) => {
-        const result = jsonSchemaValidator(value);
-        if (!result.error) {
-            const version = semver.valid(value);
-            const errors = [];
-            if (!version) {
-                errors.push({
-                    keyword: 'invalidSemverRange',
-                    dataPath: '.version',
-                    schemaPath: '',
-                    params: [],
-                    message: 'should be valid semver range for version'
-                });
-            }
-            if (errors.length) {
-                result.error = errors;
-            }
+    const result = jsonSchemaValidator(value);
+    if (!result.error) {
+        const version = semver.valid(value);
+        const errors = [];
+        if (!version) {
+            errors.push({
+                keyword: 'invalidSemverRange',
+                dataPath: '.version',
+                schemaPath: '',
+                params: [],
+                message: 'should be valid semver range for version',
+            });
         }
-        return result;
+        if (errors.length) {
+            result.error = errors;
+        }
     }
+    return result;
+};
 
-const name = createNameValidator(createValidator(eikJSONSchema.properties.name));
-const version = createVersionValidator(createValidator(eikJSONSchema.properties.version));
+const name = createNameValidator(
+    createValidator(eikJSONSchema.properties.name),
+);
+const version = createVersionValidator(
+    createValidator(eikJSONSchema.properties.version),
+);
 const type = createValidator(eikJSONSchema.properties.type);
 const server = createValidator(eikJSONSchema.properties.server);
 const files = createValidator(eikJSONSchema.properties.files);

--- a/test/classes/eik-config.test.js
+++ b/test/classes/eik-config.test.js
@@ -5,77 +5,156 @@ const EikConfig = require('../../lib/classes/eik-config');
 test('basic config properties', (t) => {
     const config = new EikConfig({
         name: 'pizza',
-        files: 'secret receipe',
-        version: 'deep dish',
+        server: 'http://server',
+        files: { '/': 'pizza' },
+        version: '0.0.0',
     });
     t.equal(config.name, 'pizza');
-    t.equal(config.files, 'secret receipe');
-    t.equal(config.version, 'deep dish');
+    t.same(config.files, { '/': 'pizza' });
+    t.equal(config.version, '0.0.0');
     t.end();
 });
 
 test('map property', (t) => {
-    let config = new EikConfig({ 'import-map': 'cheese from italy' });
-    t.deepEqual(config.map, ['cheese from italy']);
+    let config = new EikConfig({
+        name: 'pizza',
+        server: 'http://server',
+        files: { '/': 'pizza' },
+        version: '0.0.0',
+        'import-map': 'http://map',
+    });
+    t.deepEqual(config.map, ['http://map']);
 
-    config = new EikConfig({ 'import-map': ['gouda', 'mozzarella'] });
-    t.deepEqual(config.map, ['gouda', 'mozzarella']);
+    config = new EikConfig({
+        name: 'pizza',
+        server: 'http://server',
+        files: { '/': 'pizza' },
+        version: '0.0.0',
+        'import-map': ['http://map', 'http://map'],
+    });
+    t.deepEqual(config.map, ['http://map', 'http://map']);
     t.end();
 });
 
 test('out property', (t) => {
-    t.equal(new EikConfig({}).out, '.eik', 'defaults to .eik');
-    t.equal(new EikConfig({ out: 'pizza box' }).out, 'pizza box');
+    t.equal(
+        new EikConfig({
+            name: 'pizza',
+            server: 'http://server',
+            files: { '/': 'pizza' },
+            version: '0.0.0',
+        }).out,
+        '.eik',
+        'defaults to .eik',
+    );
+    t.equal(
+        new EikConfig({
+            name: 'pizza',
+            server: 'http://server',
+            files: { '/': 'pizza' },
+            version: '0.0.0',
+            out: './pizza-box',
+        }).out,
+        './pizza-box',
+    );
     t.end();
 });
 
-test('no token or server configured', (t) => {
-    const config = new EikConfig({}, null);
-    t.same(config.server, null);
+test('no token configured', (t) => {
+    const config = new EikConfig(
+        {
+            name: 'pizza',
+            server: 'http://server',
+            files: { '/': 'pizza' },
+            version: '0.0.0',
+        },
+        null,
+    );
     t.same(config.token, null);
     t.end();
 });
 
 test('single token present', (t) => {
-    const config = new EikConfig({}, [['bakery', 'muffins']]);
-    t.equal(config.server, 'bakery');
+    const config = new EikConfig(
+        {
+            name: 'pizza',
+            server: 'http://server',
+            files: { '/': 'pizza' },
+            version: '0.0.0',
+        },
+        [['http://server', 'muffins']],
+    );
+    t.equal(config.server, 'http://server');
     t.equal(config.token, 'muffins');
     t.end();
 });
 
 test('multiple tokens present', (t) => {
-    const config = new EikConfig({}, [['bakery', 'muffins'], []]);
-    t.equal(config.server, 'bakery');
+    const config = new EikConfig(
+        {
+            name: 'pizza',
+            server: 'http://server',
+            files: { '/': 'pizza' },
+            version: '0.0.0',
+        },
+        [['http://server', 'muffins'], []],
+    );
+    t.equal(config.server, 'http://server');
     t.equal(config.token, 'muffins');
     t.end();
 });
 
 test('server configured explicitly', (t) => {
-    const config = new EikConfig({ server: 'pie shop' }, [
-        ['bakery', 'muffins'],
-        ['pie shop', 'kumara pie'],
-    ]);
-    t.equal(config.server, 'pie shop');
+    const config = new EikConfig(
+        {
+            name: 'pizza',
+            server: 'http://server',
+            files: { '/': 'pizza' },
+            version: '0.0.0',
+        },
+        [
+            ['bakery', 'muffins'],
+            ['http://server', 'kumara pie'],
+        ],
+    );
+    t.equal(config.server, 'http://server');
     t.equal(config.token, 'kumara pie');
     t.end();
 });
 
 test('cwd property', (t) => {
-    const config = new EikConfig({}, null, 'pizza shop');
+    const config = new EikConfig(
+        {
+            name: 'pizza',
+            server: 'http://server',
+            files: { '/': 'pizza' },
+            version: '0.0.0',
+        },
+        null,
+        'pizza shop',
+    );
     t.equal(config.cwd, 'pizza shop');
     t.end();
 });
 
 test('setting the version', (t) => {
-    const config = new EikConfig({});
-    config.version = 'big cheese';
-    t.equal(config.version, 'big cheese');
+    const config = new EikConfig({
+        name: 'pizza',
+        server: 'http://server',
+        files: { '/': 'pizza' },
+        version: '0.0.0',
+    });
+    config.version = '0.0.1';
+    t.equal(config.version, '0.0.1');
     t.end();
 });
 
 test('pathsAndFiles returns expected contents', async (t) => {
     const config = new EikConfig(
         {
+            name: 'pizza',
+            server: 'http://server',
+            version: '0.0.0',
             files: {
                 'bakery road': 'pac*age.json',
                 'cake road': 'renov*.json',
@@ -106,6 +185,9 @@ test('pathsAndFiles handles invalid globs', async (t) => {
     t.plan(1);
     const config = new EikConfig(
         {
+            name: 'pizza',
+            server: 'http://server',
+            version: '0.0.0',
             files: {
                 'bakery road': 'ch*colate.cookie',
                 'cake road': 'renov*.json',
@@ -126,7 +208,12 @@ test('pathsAndFiles handles invalid globs', async (t) => {
 test('pathsAndFiles does not allow a destination to have multiple sources', async (t) => {
     t.plan(1);
     const config = new EikConfig(
-        { files: { 'sweet.json': '*.json' } },
+        {
+            name: 'pizza',
+            server: 'http://server',
+            version: '0.0.0',
+            files: { 'sweet.json': '*.json' },
+        },
         null,
         process.cwd(),
     );
@@ -146,7 +233,12 @@ test('pathsAndFilesAbsolute returns absolute paths on the file system', async (t
     t.plan(1);
     const baseDir = join(__dirname, '..', 'fixtures');
     const config = new EikConfig(
-        { files: { 'client.js': 'client.js' } },
+        {
+            name: 'pizza',
+            server: 'http://server',
+            version: '0.0.0',
+            files: { 'client.js': 'client.js' },
+        },
         null,
         baseDir,
     );
@@ -162,7 +254,12 @@ test('pathsAndFilesAbsolute handles files which are already absolute', async (t)
     t.plan(1);
     const baseDir = join(__dirname, '..', 'fixtures');
     const config = new EikConfig(
-        { files: { 'client.js': join(baseDir, '/client.js') } },
+        {
+            name: 'pizza',
+            server: 'http://server',
+            version: '0.0.0',
+            files: { 'client.js': join(baseDir, '/client.js') },
+        },
         null,
         baseDir,
     );

--- a/test/classes/eik-config.test.js
+++ b/test/classes/eik-config.test.js
@@ -2,13 +2,15 @@ const { test } = require('tap');
 const { join } = require('path');
 const EikConfig = require('../../lib/classes/eik-config');
 
+const validEikConfig = {
+    name: 'pizza',
+    server: 'http://server',
+    files: { '/': 'pizza' },
+    version: '0.0.0',
+};
+
 test('basic config properties', (t) => {
-    const config = new EikConfig({
-        name: 'pizza',
-        server: 'http://server',
-        files: { '/': 'pizza' },
-        version: '0.0.0',
-    });
+    const config = new EikConfig(validEikConfig);
     t.equal(config.name, 'pizza');
     t.same(config.files, { '/': 'pizza' });
     t.equal(config.version, '0.0.0');
@@ -17,19 +19,13 @@ test('basic config properties', (t) => {
 
 test('map property', (t) => {
     let config = new EikConfig({
-        name: 'pizza',
-        server: 'http://server',
-        files: { '/': 'pizza' },
-        version: '0.0.0',
+        ...validEikConfig,
         'import-map': 'http://map',
     });
     t.deepEqual(config.map, ['http://map']);
 
     config = new EikConfig({
-        name: 'pizza',
-        server: 'http://server',
-        files: { '/': 'pizza' },
-        version: '0.0.0',
+        ...validEikConfig,
         'import-map': ['http://map', 'http://map'],
     });
     t.deepEqual(config.map, ['http://map', 'http://map']);
@@ -37,22 +33,10 @@ test('map property', (t) => {
 });
 
 test('out property', (t) => {
+    t.equal(new EikConfig(validEikConfig).out, '.eik', 'defaults to .eik');
     t.equal(
         new EikConfig({
-            name: 'pizza',
-            server: 'http://server',
-            files: { '/': 'pizza' },
-            version: '0.0.0',
-        }).out,
-        '.eik',
-        'defaults to .eik',
-    );
-    t.equal(
-        new EikConfig({
-            name: 'pizza',
-            server: 'http://server',
-            files: { '/': 'pizza' },
-            version: '0.0.0',
+            ...validEikConfig,
             out: './pizza-box',
         }).out,
         './pizza-box',
@@ -61,89 +45,48 @@ test('out property', (t) => {
 });
 
 test('no token configured', (t) => {
-    const config = new EikConfig(
-        {
-            name: 'pizza',
-            server: 'http://server',
-            files: { '/': 'pizza' },
-            version: '0.0.0',
-        },
-        null,
-    );
+    const config = new EikConfig(validEikConfig, null);
     t.same(config.token, null);
     t.end();
 });
 
 test('single token present', (t) => {
-    const config = new EikConfig(
-        {
-            name: 'pizza',
-            server: 'http://server',
-            files: { '/': 'pizza' },
-            version: '0.0.0',
-        },
-        [['http://server', 'muffins']],
-    );
+    const config = new EikConfig(validEikConfig, [
+        ['http://server', 'muffins'],
+    ]);
     t.equal(config.server, 'http://server');
     t.equal(config.token, 'muffins');
     t.end();
 });
 
 test('multiple tokens present', (t) => {
-    const config = new EikConfig(
-        {
-            name: 'pizza',
-            server: 'http://server',
-            files: { '/': 'pizza' },
-            version: '0.0.0',
-        },
-        [['http://server', 'muffins'], []],
-    );
+    const config = new EikConfig(validEikConfig, [
+        ['http://server', 'muffins'],
+        [],
+    ]);
     t.equal(config.server, 'http://server');
     t.equal(config.token, 'muffins');
     t.end();
 });
 
 test('server configured explicitly', (t) => {
-    const config = new EikConfig(
-        {
-            name: 'pizza',
-            server: 'http://server',
-            files: { '/': 'pizza' },
-            version: '0.0.0',
-        },
-        [
-            ['bakery', 'muffins'],
-            ['http://server', 'kumara pie'],
-        ],
-    );
+    const config = new EikConfig(validEikConfig, [
+        ['bakery', 'muffins'],
+        ['http://server', 'kumara pie'],
+    ]);
     t.equal(config.server, 'http://server');
     t.equal(config.token, 'kumara pie');
     t.end();
 });
 
 test('cwd property', (t) => {
-    const config = new EikConfig(
-        {
-            name: 'pizza',
-            server: 'http://server',
-            files: { '/': 'pizza' },
-            version: '0.0.0',
-        },
-        null,
-        'pizza shop',
-    );
+    const config = new EikConfig(validEikConfig, null, 'pizza shop');
     t.equal(config.cwd, 'pizza shop');
     t.end();
 });
 
 test('setting the version', (t) => {
-    const config = new EikConfig({
-        name: 'pizza',
-        server: 'http://server',
-        files: { '/': 'pizza' },
-        version: '0.0.0',
-    });
+    const config = new EikConfig(validEikConfig);
     config.version = '0.0.1';
     t.equal(config.version, '0.0.1');
     t.end();
@@ -152,9 +95,7 @@ test('setting the version', (t) => {
 test('pathsAndFiles returns expected contents', async (t) => {
     const config = new EikConfig(
         {
-            name: 'pizza',
-            server: 'http://server',
-            version: '0.0.0',
+            ...validEikConfig,
             files: {
                 'bakery road': 'pac*age.json',
                 'cake road': 'renov*.json',
@@ -185,9 +126,7 @@ test('pathsAndFiles handles invalid globs', async (t) => {
     t.plan(1);
     const config = new EikConfig(
         {
-            name: 'pizza',
-            server: 'http://server',
-            version: '0.0.0',
+            ...validEikConfig,
             files: {
                 'bakery road': 'ch*colate.cookie',
                 'cake road': 'renov*.json',
@@ -209,9 +148,7 @@ test('pathsAndFiles does not allow a destination to have multiple sources', asyn
     t.plan(1);
     const config = new EikConfig(
         {
-            name: 'pizza',
-            server: 'http://server',
-            version: '0.0.0',
+            ...validEikConfig,
             files: { 'sweet.json': '*.json' },
         },
         null,
@@ -234,9 +171,7 @@ test('pathsAndFilesAbsolute returns absolute paths on the file system', async (t
     const baseDir = join(__dirname, '..', 'fixtures');
     const config = new EikConfig(
         {
-            name: 'pizza',
-            server: 'http://server',
-            version: '0.0.0',
+            ...validEikConfig,
             files: { 'client.js': 'client.js' },
         },
         null,
@@ -255,9 +190,7 @@ test('pathsAndFilesAbsolute handles files which are already absolute', async (t)
     const baseDir = join(__dirname, '..', 'fixtures');
     const config = new EikConfig(
         {
-            name: 'pizza',
-            server: 'http://server',
-            version: '0.0.0',
+            ...validEikConfig,
             files: { 'client.js': join(baseDir, '/client.js') },
         },
         null,

--- a/test/helpers/config-store.test.js
+++ b/test/helpers/config-store.test.js
@@ -60,6 +60,19 @@ test('loads from eik.json', (t) => {
     t.end();
 });
 
+test('loads from eik.json - invalid config', (t) => {
+    try {
+        configStore.findInDirectory('pizza dir', (path) => {
+            if (path.includes('package.json') || path.includes('.eikrc'))
+                return null;
+            return {};
+        });
+    } catch(err) {
+        t.match(`${err}`, `InvalidConfigError: Eik config object was invalid: 'config.findInDirectory operation failed: Invalid eik.json schema: should have required property 'server'`);
+    }
+    t.end();
+});
+
 test('package.json and eik.json not being present', (t) => {
     t.plan(1);
     try {
@@ -177,6 +190,28 @@ test('saves config to disk', async (t) => {
 
     const persistedConfig = configStore.findInDirectory(path);
     t.equal(persistedConfig.out, './biscuits');
+    t.end();
+});
+
+test('saves config to disk - invalid config - passed config not a instance of EikConfig', async (t) => {
+    const config = {}
+    try {
+        configStore.persistToDisk(config);
+    } catch(err) {
+        t.match(`${err}`, `InvalidConfigError: Eik config object was invalid: 'config.persistToDisk operation failed: config.validate is not a function'`);
+    }
+
+    t.end();
+});
+
+test('saves config to disk - invalid config', async (t) => {
+    const config = new EikConfig({});
+    try {
+        configStore.persistToDisk(config);
+    } catch(err) {
+        t.match(`${err}`, `InvalidConfigError: Eik config object was invalid: 'config.persistToDisk operation failed: Invalid eik.json schema: should have required property 'server'`);
+    }
+
     t.end();
 });
 

--- a/test/helpers/config-store.test.js
+++ b/test/helpers/config-store.test.js
@@ -15,17 +15,19 @@ test('loads from package.json', (t) => {
         t.match(path, 'pizza dir/package.json');
         return {
             name: 'magarita',
-            version: 'tomato',
+            version: '0.0.0',
             notIncluded: 'fish',
             eik: {
-                'import-map': 'deep dish',
+                server: 'http://server',
+                files: { '/': 'pizza' },
+                'import-map': 'http://map',
             },
         };
     });
     t.equal(config.name, 'magarita');
-    t.equal(config.version, 'tomato');
+    t.equal(config.version, '0.0.0');
     t.equal(config.notIncluded, undefined);
-    t.deepEqual(config.map, ['deep dish']);
+    t.deepEqual(config.map, ['http://map']);
     t.end();
 });
 
@@ -36,6 +38,9 @@ test('loads from eik.json', (t) => {
         t.match(path, 'pizza dir/eik.json');
         return {
             name: 'magarita',
+            server: 'http://server',
+            files: { '/': 'pizza' },
+            version: '0.0.0',
         };
     });
     t.equal(config.name, 'magarita');
@@ -76,23 +81,38 @@ test('package.json and eik.json both have eik config', (t) => {
 
 test('name is pulled from package.json if not defined in eik.json', (t) => {
     const jsonReaderStub = (path) => {
-        if (path.includes('package.json')) return { name: 'big pizza co' };
-        if (path.includes('eik.json')) return { version: 'bigger and better' };
+        if (path.includes('package.json'))
+            return {
+                name: 'big pizza co',
+                version: '0.0.0',
+            };
+        if (path.includes('eik.json'))
+            return {
+                server: 'http://server',
+                files: { '/': 'pizza' },
+            };
         return {};
     };
     const config = configStore.findInDirectory('pizza dir', jsonReaderStub);
     t.equal(config.name, 'big pizza co');
-    t.equal(config.version, 'bigger and better');
-    t.equal(config.version, 'bigger and better');
+    t.equal(config.version, '0.0.0');
     t.end();
 });
 
 test('tokens are present', (t) => {
     const config = configStore.findInDirectory('pizza dir', (path) => {
-        if (path.includes('.eikrc')) return { tokens: [['bakery', 'muffins']] };
+        if (path.includes('eik.json'))
+            return {
+                name: 'magarita',
+                server: 'http://server',
+                files: { '/': 'pizza' },
+                version: '0.0.0',
+            };
+        if (path.includes('.eikrc'))
+            return { tokens: [['http://server', 'muffins']] };
         return {};
     });
-    t.equal(config.server, 'bakery');
+    t.equal(config.server, 'http://server');
     t.equal(config.token, 'muffins');
     t.end();
 });
@@ -133,18 +153,34 @@ test('reading without stubbed json', (t) => {
 
 test('saves config to disk', async (t) => {
     const path = await mkdirTempDir();
-    const config = new EikConfig({ out: 'muffins' }, null, path);
+    const config = new EikConfig(
+        {
+            name: 'magarita',
+            server: 'http://server',
+            files: { '/': 'pizza' },
+            version: '0.0.0',
+            out: './biscuits',
+        },
+        null,
+        path,
+    );
 
     configStore.persistToDisk(config);
 
     const persistedConfig = configStore.findInDirectory(path);
-    t.equal(persistedConfig.out, 'muffins');
+    t.equal(persistedConfig.out, './biscuits');
     t.end();
 });
 
 test('handles no path being provided', async (t) => {
     t.plan(1);
-    const config = new EikConfig({ out: 'muffins' });
+    const config = new EikConfig({
+        name: 'magarita',
+        server: 'http://server',
+        files: { '/': 'pizza' },
+        version: '0.0.0',
+        out: 'muffins',
+    });
 
     try {
         configStore.persistToDisk(config);

--- a/test/schemas/assert.js
+++ b/test/schemas/assert.js
@@ -1,7 +1,7 @@
 const { test } = require('tap');
 const { assert } = require('../../lib/schemas/index');
 
-test('assert basic eik JSON file', t => {
+test('assert basic eik JSON file', (t) => {
     t.notThrow(() => {
         assert.eikJSON({
             name: 'my-app-name',
@@ -16,7 +16,32 @@ test('assert basic eik JSON file', t => {
     t.end();
 });
 
-test('assert asset manifest - all props invalid', t => {
+test('assert eik JSON file - mutation does not occur', (t) => {
+    const data = {
+        name: 'my-app-name',
+        version: '1.0.0',
+        server: 'http://localhost:4001',
+        files: {
+            'index.js': './assets/scripts.js',
+            'index.css': './assets/styles.css',
+        },
+    };
+
+    assert.eikJSON(data);
+
+    t.same(data, {
+        name: 'my-app-name',
+        version: '1.0.0',
+        server: 'http://localhost:4001',
+        files: {
+            'index.js': './assets/scripts.js',
+            'index.css': './assets/styles.css',
+        },
+    });
+    t.end();
+});
+
+test('assert asset manifest - all props invalid', (t) => {
     t.throws(() => {
         assert.eikJSON({
             name: '',
@@ -25,122 +50,125 @@ test('assert asset manifest - all props invalid', t => {
     t.end();
 });
 
-test('assert name: empty string', t => {
+test('assert name: empty string', (t) => {
     t.throws(() => {
         assert.name('');
     });
     t.end();
 });
 
-test('assert name: valid', t => {
+test('assert name: valid', (t) => {
     t.notThrow(() => {
         assert.name('@finn-no/my-app');
     });
     t.end();
 });
 
-test('assert name: invalid by assert-npm-package-name module', t => {
+test('assert name: invalid by assert-npm-package-name module', (t) => {
     t.throws(() => {
         assert.name('@finn-no/my-app~');
     });
     t.end();
 });
 
-test('assert version: empty string', t => {
+test('assert version: empty string', (t) => {
     t.throws(() => {
         assert.version('');
     });
     t.end();
 });
 
-test('assert version: valid', t => {
+test('assert version: valid', (t) => {
     t.notThrow(() => {
         assert.version('1.0.0');
     });
     t.end();
 });
 
-test('assert type: invalid', t => {
+test('assert type: invalid', (t) => {
     t.plan(1);
     try {
         assert.type('foo');
     } catch (err) {
-        t.equal(err.message, 'Parameter "type" is not valid: should be equal to one of the allowed values ("package", npm", map")');
+        t.equal(
+            err.message,
+            'Parameter "type" is not valid: should be equal to one of the allowed values ("package", npm", map")',
+        );
     }
     t.end();
 });
 
-test('assert type: valid - package', t => {
+test('assert type: valid - package', (t) => {
     t.notThrow(() => {
         assert.type('package');
     });
     t.end();
 });
 
-test('assert type: valid - npm', t => {
+test('assert type: valid - npm', (t) => {
     t.notThrow(() => {
         assert.type('npm');
     });
     t.end();
 });
 
-test('assert type: valid - map', t => {
+test('assert type: valid - map', (t) => {
     t.notThrow(() => {
         assert.type('map');
     });
     t.end();
 });
 
-test('assert version: invalid by node-semver module', t => {
+test('assert version: invalid by node-semver module', (t) => {
     t.throws(() => {
         assert.version('1.0');
     });
     t.end();
 });
 
-test('assert server: valid', t => {
+test('assert server: valid', (t) => {
     t.notThrow(() => {
         assert.server('http://localhost:4000');
     });
     t.end();
 });
 
-test('assert server: invalid', t => {
+test('assert server: invalid', (t) => {
     t.throws(() => {
         assert.server('localhost');
     });
     t.end();
 });
 
-test('assert files: valid', t => {
+test('assert files: valid', (t) => {
     t.notThrow(() => {
         assert.files({ 'index.js': '/path/to/file.js' });
     });
     t.end();
 });
 
-test('assert files: invalid', t => {
+test('assert files: invalid', (t) => {
     t.throws(() => {
         assert.files({ asd: 1 });
     });
     t.end();
 });
 
-test('assert files: invalid', t => {
+test('assert files: invalid', (t) => {
     t.throws(() => {
         assert.files({});
     });
     t.end();
 });
 
-test('assert importMap: valid string', t => {
+test('assert importMap: valid string', (t) => {
     t.notThrow(() => {
         assert.importMap('http://myimportmap/file.json');
     });
     t.end();
 });
 
-test('assert importMap: valid array', t => {
+test('assert importMap: valid array', (t) => {
     t.notThrow(() => {
         assert.importMap([
             'http://myimportmap/file1.json',
@@ -150,28 +178,28 @@ test('assert importMap: valid array', t => {
     t.end();
 });
 
-test('assert importMap: invalid string', t => {
+test('assert importMap: invalid string', (t) => {
     t.throws(() => {
         assert.importMap('');
     });
     t.end();
 });
 
-test('assert importMap: invalid array', t => {
+test('assert importMap: invalid array', (t) => {
     t.throws(() => {
         assert.importMap(['']);
     });
     t.end();
 });
 
-test('assert out: valid', t => {
+test('assert out: valid', (t) => {
     t.notThrow(() => {
         assert.out('./.eik');
     });
     t.end();
 });
 
-test('assert out: invalid', t => {
+test('assert out: invalid', (t) => {
     t.throws(() => {
         assert.out('');
     });


### PR DESCRIPTION
Adds type field
Changes validation method to no longer mutate subject being validated
Adds validation to config class constructor and setters

BREAKING CHANGE: valid eik config object is now required when instantiating EikConfig class