### PR TITLE
fix: correctly return default type from eik-config class

### DIFF
--- a/lib/classes/eik-config.js
+++ b/lib/classes/eik-config.js
@@ -3,7 +3,7 @@ const path = require('path');
 const glob = promisify(require('glob'));
 const NoFilesMatchedError = require('./no-files-matched-error');
 const SingleDestMultipleSourcesError = require('./single-dest-multiple-source-error');
-const { assert } = require('../schemas');
+const { assert, schema } = require('../schemas');
 
 const _config = Symbol('config');
 const _tokens = Symbol('tokens');
@@ -30,7 +30,7 @@ module.exports = class EikConfig {
     }
 
     get type() {
-        return this[_config].type || 'package';
+        return this[_config].type || schema.properties.type.default;
     }
 
     get server() {

--- a/lib/classes/eik-config.js
+++ b/lib/classes/eik-config.js
@@ -3,7 +3,7 @@ const path = require('path');
 const glob = promisify(require('glob'));
 const NoFilesMatchedError = require('./no-files-matched-error');
 const SingleDestMultipleSourcesError = require('./single-dest-multiple-source-error');
-const { validate, assert } = require('../schemas');
+const { assert } = require('../schemas');
 
 const _config = Symbol('config');
 const _tokens = Symbol('tokens');
@@ -30,8 +30,7 @@ module.exports = class EikConfig {
     }
 
     get type() {
-        const valid = validate.type(this[_config].type);
-        return valid.value;
+        return this[_config].type || 'package';
     }
 
     get server() {

--- a/test/classes/eik-config.test.js
+++ b/test/classes/eik-config.test.js
@@ -92,6 +92,12 @@ test('setting the version', (t) => {
     t.end();
 });
 
+test('getting the type - default value', (t) => {
+    const config = new EikConfig(validEikConfig);
+    t.equal(config.type, 'package');
+    t.end();
+});
+
 test('pathsAndFiles returns expected contents', async (t) => {
     const config = new EikConfig(
         {


### PR DESCRIPTION
I couldn't get AJV to use the default value in the schema when validating a single value so I've moved to just hard coding the default value.