### PR TITLE
fix: do not use package.json as config source if eik key is not defined

### DIFF
--- a/lib/helpers/config-store.js
+++ b/lib/helpers/config-store.js
@@ -38,8 +38,10 @@ module.exports = {
         }
         let assets;
         if (pkgJSON) {
-            const { name, version } = pkgJSON;
-            assets = { name, version, ...pkgJSON.eik };
+            const { name, version, eik } = pkgJSON;
+            if (eik) {
+                assets = { name, version, ...pkgJSON.eik };
+            }
         }
         if (eikJSON) {
             assets = { ...assets, ...eikJSON };

--- a/test/helpers/config-store.test.js
+++ b/test/helpers/config-store.test.js
@@ -111,17 +111,24 @@ test('name is pulled from package.json if not defined in eik.json', (t) => {
             return {
                 name: 'big pizza co',
                 version: '0.0.0',
+                eik: {
+                    server: 'https://test',
+                    files: {
+                        '/': './dist/**/*.js'
+                    },
+                },
             };
         if (path.includes('eik.json'))
-            return {
-                server: 'http://server',
-                files: { '/': 'pizza' },
-            };
+            return null;
         return {};
     };
     const config = configStore.findInDirectory('pizza dir', jsonReaderStub);
     t.equal(config.name, 'big pizza co');
     t.equal(config.version, '0.0.0');
+    t.equal(config.server, 'https://test');
+    t.same(config.files, {
+        '/': './dist/**/*.js'
+    });
     t.end();
 });
 


### PR DESCRIPTION
This makes it so that config will ignore package.json files whenever an eik key is not defined (in package.json) 