### PR TITLE
chore(build): add type definition file to published package

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 coverage
+types

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tmp/**/*
 coverage
 .vscode
 eik.json
+types

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,4 +12,4 @@ coverage
 .vscode
 eikjson.d.ts
 CHANGELOG.md
-dist
+types

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,4 @@ coverage
 .vscode
 eikjson.d.ts
 CHANGELOG.md
+dist

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "4.0.0-next.1",
   "description": "Common utilities for Eik modules",
   "main": "lib/index.js",
+  "types": "types/index.d.ts",
   "files": [
     "CHANGELOG.md",
     "package.json",
-    "lib"
+    "lib",
+    "types"
   ],
   "scripts": {
     "test": "tap --test-regex=.test.js --test-ignore=node_modules",
@@ -16,7 +18,8 @@
     "schema:outdated": "npm run schema:types && git diff --exit-code HEAD:eikjson.d.ts eikjson.d.ts",
     "style:check": "prettier -c .",
     "style:format": "prettier -w .",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "prepublish": "npm run typecheck"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,10 @@
     "checkJs": true,
     "allowJs": true,
     "moduleResolution": "node",
-    "noEmit": true
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "types"
   },
   "include": ["lib"]
 }


### PR DESCRIPTION
This PR adds automated type definition building whenever a new version is published via a pre-publish hook. Type definitions are not committed to source control.