### PR TITLE
fix: update require statements to avoid circular dependencies

### DIFF
--- a/lib/classes/eik-config.js
+++ b/lib/classes/eik-config.js
@@ -10,7 +10,9 @@ const SingleDestMultipleSourcesError = require('./single-dest-multiple-source-er
 const FileMapping = require('./file-mapping');
 const RemoteFileLocation = require('./remote-file-location');
 const schemas = require('../schemas');
-const { typeSlug, removeTrailingSlash, resolveFiles } = require('../helpers');
+const { removeTrailingSlash } = require('../helpers/path-slashes');
+const typeSlug = require('../helpers/type-slug');
+const resolveFiles = require('../helpers/resolve-files');
 
 const _config = Symbol('config');
 const _tokens = Symbol('tokens');


### PR DESCRIPTION
Used madge to detect circular dependencies. `npx madge -c .`

```
✖ Found 2 circular dependencies!

1) lib/classes/eik-config.js > lib/helpers/index.js > lib/helpers/config-store.js
2) lib/classes/eik-config.js > lib/helpers/index.js > lib/helpers/get-defaults.js
```

This PR fixes them