### PR TITLE
Fix workspace deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   "devDependencies": {
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
-    "semantic-release": "21.0.5"
+    "semantic-release": "21.0.7"
   }
 }

--- a/packages/common-config-loader/package.json
+++ b/packages/common-config-loader/package.json
@@ -14,8 +14,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@eik/common-schemas": "file:../common-schemas",
-    "@eik/common-utils": "file:../common-utils",
+    "@eik/common-schemas": "^4.0.0-next.11",
+    "@eik/common-utils": "^4.0.0-next.11",
     "glob": "10.3.0",
     "is-glob": "4.0.3",
     "mime-types": "2.1.35"


### PR DESCRIPTION
Depending on files from `file:` breaks when the modules have been published.