### PR TITLE
fix: keep internal consistency with glob and paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         node-version: [18, 20]
     runs-on: ${{ matrix.os }}
 

--- a/lib/classes/eik-config.js
+++ b/lib/classes/eik-config.js
@@ -8,7 +8,7 @@ import SingleDestMultipleSourcesError from './single-dest-multiple-source-error.
 import FileMapping from './file-mapping.js';
 import RemoteFileLocation from './remote-file-location.js';
 import schemas from '../schemas/index.js';
-import { removeTrailingSlash } from '../helpers/path-slashes.js';
+import { removeTrailingSlash, ensurePosix } from '../helpers/path-slashes.js';
 import typeSlug from '../helpers/type-slug.js';
 import resolveFiles from '../helpers/resolve-files.js';
 
@@ -152,13 +152,10 @@ export default class EikConfig {
                 const shouldMapFilename = extname(destination);
                 const relativePathname = shouldMapFilename
                     ? destination
-                    : join(destination, localFile.relative).replace(/\\/g, '/');
-                const packagePathname = join(
-                    // @ts-ignore
-                    typeSlug(this.type),
-                    this.name,
-                    this.version,
-                ).replace(/\\/g, '/');
+                    : ensurePosix(join(destination, localFile.relative));
+                const packagePathname = ensurePosix(
+                    join(typeSlug(this.type), this.name, this.version),
+                );
 
                 const remoteDestination = new RemoteFileLocation(
                     relativePathname,

--- a/lib/classes/eik-config.js
+++ b/lib/classes/eik-config.js
@@ -152,13 +152,14 @@ export default class EikConfig {
                 const shouldMapFilename = extname(destination);
                 const relativePathname = shouldMapFilename
                     ? destination
-                    : join(destination, localFile.relative);
+                    : join(destination, localFile.relative).replace(/\\/g, '/');
                 const packagePathname = join(
                     // @ts-ignore
                     typeSlug(this.type),
                     this.name,
                     this.version,
-                );
+                ).replace(/\\/g, '/');
+
                 const remoteDestination = new RemoteFileLocation(
                     relativePathname,
                     packagePathname,

--- a/lib/classes/local-file-location.js
+++ b/lib/classes/local-file-location.js
@@ -5,6 +5,7 @@ import assert from 'node:assert';
 import { join, extname, isAbsolute } from 'node:path';
 // @ts-ignore
 import mime from 'mime-types';
+import { ensurePosix } from '../helpers/path-slashes.js';
 
 /**
  * Class containing information about a local file
@@ -36,7 +37,7 @@ class LocalFileLocation {
          * @type {string} absolute path to file on disk,
          * this is a concatentation of this.basePath and this.relative
          */
-        this.absolute = join(basePath, path).replace(/\\/g, '/');
+        this.absolute = ensurePosix(join(basePath, path));
 
         /**
          * @type {string} file extension with "." character included. (eg. ".json")

--- a/lib/classes/local-file-location.js
+++ b/lib/classes/local-file-location.js
@@ -21,7 +21,10 @@ class LocalFileLocation {
             typeof basePath === 'string',
             '"basePath" must be of type "string"',
         );
-        assert(!isAbsolute(path), '"path" must be a relative path');
+        assert(
+            !isAbsolute(path),
+            `"path" must be a relative path, got ${path}`,
+        );
 
         /**
          * @type {string} path to file on disk relative to this.basePath

--- a/lib/classes/local-file-location.js
+++ b/lib/classes/local-file-location.js
@@ -36,7 +36,7 @@ class LocalFileLocation {
          * @type {string} absolute path to file on disk,
          * this is a concatentation of this.basePath and this.relative
          */
-        this.absolute = join(basePath, path);
+        this.absolute = join(basePath, path).replace(/\\/g, '/');
 
         /**
          * @type {string} file extension with "." character included. (eg. ".json")

--- a/lib/classes/resolved-files.js
+++ b/lib/classes/resolved-files.js
@@ -46,7 +46,9 @@ class ResolvedFiles {
     *[Symbol.iterator]() {
         for (const file of this[originalFiles]) {
             const relative = removeTrailingSlash(
-                removeLeadingSlash(file.replace(this.basePath, '')),
+                removeLeadingSlash(
+                    file.replace(/\\/g, '/').replace(this.basePath, ''),
+                ),
             );
             yield new LocalFileLocation(relative, this.basePath);
         }

--- a/lib/helpers/path-slashes.js
+++ b/lib/helpers/path-slashes.js
@@ -1,5 +1,5 @@
-const { sep } = require('path');
-const { platform } = require('os');
+import { sep } from 'path';
+import { platform } from 'os';
 
 /**
  * Add a trailing slash to a path if necessary
@@ -8,7 +8,7 @@ const { platform } = require('os');
  *
  * @returns {string}
  */
-const addTrailingSlash = (val) => (val.endsWith('/') ? val : `${val}/`);
+export const addTrailingSlash = (val) => (val.endsWith('/') ? val : `${val}/`);
 
 /**
  * Remove a trailing slash from a path if necessary
@@ -17,7 +17,7 @@ const addTrailingSlash = (val) => (val.endsWith('/') ? val : `${val}/`);
  *
  * @returns {string}
  */
-const removeTrailingSlash = (val) =>
+export const removeTrailingSlash = (val) =>
     // this is also used to trim from config files, which may now always use the OS's sep value. Look for both.
     val.endsWith('/') || val.endsWith('\\')
         ? val.substr(0, val.length - 1)
@@ -30,7 +30,7 @@ const removeTrailingSlash = (val) =>
  *
  * @returns {string}
  */
-const addLeadingSlash = (val) =>
+export const addLeadingSlash = (val) =>
     val.startsWith('/') || platform() === 'win32' ? val : `/${val}`;
 
 /**
@@ -40,7 +40,7 @@ const addLeadingSlash = (val) =>
  *
  * @returns {string}
  */
-const removeLeadingSlash = (val) =>
+export const removeLeadingSlash = (val) =>
     val.startsWith('/') || val.startsWith('\\') ? val.substr(1) : val;
 
 /**
@@ -48,12 +48,11 @@ const removeLeadingSlash = (val) =>
  * @param {string} val
  * @returns {string}
  */
-const ensureOsSep = (val) => val.replace(/\/\\/g, sep);
+export const ensureOsSep = (val) => val.replace(/\/\\/g, sep);
 
-export {
-    ensureOsSep,
-    addTrailingSlash,
-    removeTrailingSlash,
-    addLeadingSlash,
-    removeLeadingSlash,
-};
+/**
+ * Replaces any backslash with a forward slash.
+ * @param {string} val
+ * @returns {string}
+ */
+export const ensurePosix = (val) => val.replace(/\\/g, '/');

--- a/lib/helpers/path-slashes.js
+++ b/lib/helpers/path-slashes.js
@@ -1,3 +1,6 @@
+const { sep } = require('path');
+const { platform } = require('os');
+
 /**
  * Add a trailing slash to a path if necessary
  *
@@ -15,16 +18,20 @@ const addTrailingSlash = (val) => (val.endsWith('/') ? val : `${val}/`);
  * @returns {string}
  */
 const removeTrailingSlash = (val) =>
-    val.endsWith('/') ? val.substr(0, val.length - 1) : val;
+    // this is also used to trim from config files, which may now always use the OS's sep value. Look for both.
+    val.endsWith('/') || val.endsWith('\\')
+        ? val.substr(0, val.length - 1)
+        : val;
 
 /**
- * Add a leading slash to a path if necessary
+ * Add a leading slash to a path if necessary, but not on Windows
  *
  * @param {string} val
  *
  * @returns {string}
  */
-const addLeadingSlash = (val) => (val.startsWith('/') ? val : `/${val}`);
+const addLeadingSlash = (val) =>
+    val.startsWith('/') || platform() === 'win32' ? val : `/${val}`;
 
 /**
  * Remove a leading slash from a path if necessary
@@ -33,9 +40,18 @@ const addLeadingSlash = (val) => (val.startsWith('/') ? val : `/${val}`);
  *
  * @returns {string}
  */
-const removeLeadingSlash = (val) => (val.startsWith('/') ? val.substr(1) : val);
+const removeLeadingSlash = (val) =>
+    val.startsWith('/') || val.startsWith('\\') ? val.substr(1) : val;
+
+/**
+ * Replaces a path string's separators (/ or \) with the current OS's sep value from node:path.
+ * @param {string} val
+ * @returns {string}
+ */
+const ensureOsSep = (val) => val.replace(/\/\\/g, sep);
 
 export {
+    ensureOsSep,
     addTrailingSlash,
     removeTrailingSlash,
     addLeadingSlash,

--- a/lib/helpers/resolve-files.js
+++ b/lib/helpers/resolve-files.js
@@ -53,7 +53,7 @@ const resolveFiles = async (files, cwd) =>
 
             // append glob if folder
             if (extname(pattern) === '' && isGlob(pattern) === false) {
-                pattern = join(pattern, `${sep}**${sep}*`);
+                pattern = join(pattern, `/**/*`);
             }
 
             // trim off any glob

--- a/lib/helpers/resolve-files.js
+++ b/lib/helpers/resolve-files.js
@@ -5,6 +5,7 @@ import {
     removeTrailingSlash,
     addLeadingSlash,
     removeLeadingSlash,
+    ensureOsSep,
 } from './path-slashes.js';
 import ResolvedFiles from '../classes/resolved-files.js';
 
@@ -23,6 +24,7 @@ const pathUntilGlob = (path) => {
         if (isGlob(segment)) break;
         segmentsToKeep.push(segment);
     }
+
     return addLeadingSlash(normalize(segmentsToKeep.join(sep)));
 };
 
@@ -37,13 +39,18 @@ const pathUntilGlob = (path) => {
 const resolveFiles = async (files, cwd) =>
     Promise.all(
         Object.entries(files).map(async (definition) => {
-            const [, source] = definition;
+            let [, source] = definition;
+
+            // The config may not always match the OS's separator.
+            // Convert the input to OS-specific if necessary.
+            source = ensureOsSep(source);
+
             // normalise to absolute path
             let pattern = isAbsolute(source) ? source : join(cwd, source);
 
             // append glob if folder
             if (extname(pattern) === '' && isGlob(pattern) === false) {
-                pattern = join(pattern, '/**/*');
+                pattern = join(pattern, `${sep}**${sep}*`);
             }
 
             // trim off any glob
@@ -55,6 +62,11 @@ const resolveFiles = async (files, cwd) =>
                     basePath.replace(basename(pattern), ''),
                 );
             }
+
+            // convert glob pattern to forward slash separators
+            // https://www.npmjs.com/package/glob#windows
+            basePath = basePath.replace(/\\/g, '/');
+            pattern = pattern.replace(/\\/g, '/');
 
             // process glob pattern into a list of existing files
             const resolvedFiles = await glob(pattern, {

--- a/lib/helpers/resolve-files.js
+++ b/lib/helpers/resolve-files.js
@@ -43,6 +43,9 @@ const resolveFiles = async (files, cwd) =>
 
             // The config may not always match the OS's separator.
             // Convert the input to OS-specific if necessary.
+            // We convert back to always using forward slashes for glob,
+            // but for calculating the paths relative to cwd we'd like
+            // these to be OS-specific for now.
             source = ensureOsSep(source);
 
             // normalise to absolute path

--- a/lib/helpers/resolve-files.js
+++ b/lib/helpers/resolve-files.js
@@ -6,6 +6,7 @@ import {
     addLeadingSlash,
     removeLeadingSlash,
     ensureOsSep,
+    ensurePosix,
 } from './path-slashes.js';
 import ResolvedFiles from '../classes/resolved-files.js';
 
@@ -68,8 +69,8 @@ const resolveFiles = async (files, cwd) =>
 
             // convert glob pattern to forward slash separators
             // https://www.npmjs.com/package/glob#windows
-            basePath = basePath.replace(/\\/g, '/');
-            pattern = pattern.replace(/\\/g, '/');
+            basePath = ensurePosix(basePath);
+            pattern = ensurePosix(pattern);
 
             // process glob pattern into a list of existing files
             const resolvedFiles = await glob(pattern, {

--- a/lib/helpers/resolve-files.js
+++ b/lib/helpers/resolve-files.js
@@ -53,8 +53,11 @@ const resolveFiles = async (files, cwd) =>
             let pattern = isAbsolute(source) ? source : join(cwd, source);
 
             // append glob if folder
-            if (extname(pattern) === '' && isGlob(pattern) === false) {
-                pattern = join(pattern, `/**/*`);
+            if (
+                extname(pattern) === '' &&
+                isGlob(ensurePosix(pattern)) === false
+            ) {
+                pattern = `${pattern}${sep}**${sep}*`;
             }
 
             // trim off any glob

--- a/test/classes/eik-config/mappings.test.js
+++ b/test/classes/eik-config/mappings.test.js
@@ -18,7 +18,7 @@ const validEikConfig = {
 
 const baseDir = join(__dirname, '../../fixtures');
 
-test('mappings - directory given', async (t) => {
+test('mappings - directory given', { only: true }, async (t) => {
     const config = new EikConfig(
         {
             ...validEikConfig,
@@ -280,7 +280,10 @@ test('mappings - files is an object - remaps name of file - absolute path to fil
         {
             ...validEikConfig,
             files: {
-                'script.js': join(baseDir, 'folder/client.js'),
+                'script.js': join(baseDir, 'folder/client.js').replace(
+                    /\\/g,
+                    '/',
+                ),
             },
         },
         null,
@@ -306,7 +309,7 @@ test('mappings - files is an object - mapped to folder - absolute path to folder
         {
             ...validEikConfig,
             files: {
-                folder: join(baseDir, 'folder'),
+                folder: join(baseDir, 'folder').replace(/\\/g, '/'),
             },
         },
         null,
@@ -493,7 +496,7 @@ test('mappings - files is an object - mapped to folder - absolute path to folder
         {
             ...validEikConfig,
             files: {
-                folder: join(baseDir, 'folder'),
+                folder: join(baseDir, 'folder').replace(/\\/g, '/'),
             },
         },
         null,

--- a/test/classes/eik-config/mappings.test.js
+++ b/test/classes/eik-config/mappings.test.js
@@ -18,7 +18,7 @@ const validEikConfig = {
 
 const baseDir = join(__dirname, '../../fixtures');
 
-test('mappings - directory given', { only: true }, async (t) => {
+test('mappings - directory given', async (t) => {
     const config = new EikConfig(
         {
             ...validEikConfig,

--- a/test/classes/eik-config/mappings.test.js
+++ b/test/classes/eik-config/mappings.test.js
@@ -5,6 +5,7 @@ import FileMapping from '../../../lib/classes/file-mapping.js';
 import LocalFileLocation from '../../../lib/classes/local-file-location.js';
 import RemoteFileLocation from '../../../lib/classes/remote-file-location.js';
 import EikConfig from '../../../lib/classes/eik-config.js';
+import { ensurePosix } from '../../../lib/helpers/path-slashes.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -309,7 +310,7 @@ test('mappings - files is an object - mapped to folder - absolute path to folder
         {
             ...validEikConfig,
             files: {
-                folder: join(baseDir, 'folder').replace(/\\/g, '/'),
+                folder: ensurePosix(join(baseDir, 'folder')),
             },
         },
         null,
@@ -496,7 +497,7 @@ test('mappings - files is an object - mapped to folder - absolute path to folder
         {
             ...validEikConfig,
             files: {
-                folder: join(baseDir, 'folder').replace(/\\/g, '/'),
+                folder: ensurePosix(join(baseDir, 'folder')),
             },
         },
         null,

--- a/test/helpers/config-store.test.js
+++ b/test/helpers/config-store.test.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import { join, dirname } from 'node:path';
+import { join, dirname, sep } from 'node:path';
 import os from 'node:os';
 import { test } from 'tap';
 import configStore from '../../lib/helpers/config-store.js';
@@ -38,9 +38,9 @@ const mockPackageJSON = ({
 });
 
 test('loads from package.json', (t) => {
-    const config = configStore.findInDirectory('/pizza dir', (path) => {
+    const config = configStore.findInDirectory(`${sep}pizza dir`, (path) => {
         if (path.includes('eik.json') || path.includes('.eikrc')) return null;
-        t.match(path, '/pizza dir/package.json');
+        t.match(path, `${sep}pizza dir${sep}package.json`);
         return mockPackageJSON({
             other: { notIncluded: 'fish' },
             eik: { 'import-map': 'http://map' },
@@ -55,10 +55,10 @@ test('loads from package.json', (t) => {
 });
 
 test('loads from eik.json', (t) => {
-    const config = configStore.findInDirectory('/pizza dir', (path) => {
+    const config = configStore.findInDirectory(`${sep}pizza dir`, (path) => {
         if (path.includes('package.json') || path.includes('.eikrc'))
             return null;
-        t.match(path, '/pizza dir/eik.json');
+        t.match(path, `${sep}pizza dir${sep}eik.json`);
         return mockEikJSON();
     });
     t.equal(config.name, 'magarita');
@@ -81,7 +81,7 @@ test('loads eik.json from an exact path', (t) => {
 
 test('loads from eik.json - invalid config', (t) => {
     try {
-        configStore.findInDirectory('/pizza dir', (path) => {
+        configStore.findInDirectory(`${sep}pizza dir`, (path) => {
             if (path.includes('package.json') || path.includes('.eikrc'))
                 return null;
             return {};
@@ -98,11 +98,11 @@ test('loads from eik.json - invalid config', (t) => {
 test('package.json and eik.json not being present', (t) => {
     t.plan(1);
     try {
-        configStore.findInDirectory('/pizza dir', () => null);
+        configStore.findInDirectory(`${sep}pizza dir`, () => null);
     } catch (e) {
         t.equal(
             e.message,
-            "No package.json or eik.json file found in: '/pizza dir'",
+            `No package.json or eik.json file found in: '${sep}pizza dir'`,
         );
     }
     t.end();
@@ -116,7 +116,7 @@ test('package.json and eik.json both have eik config', (t) => {
         return {};
     };
     try {
-        configStore.findInDirectory('/pizza dir', jsonReaderStub);
+        configStore.findInDirectory(`${sep}pizza dir`, jsonReaderStub);
     } catch (e) {
         t.equal(
             e.message,
@@ -143,7 +143,10 @@ test('name is pulled from package.json if not defined in eik.json', (t) => {
         if (path.includes('eik.json')) return null;
         return {};
     };
-    const config = configStore.findInDirectory('/pizza dir', jsonReaderStub);
+    const config = configStore.findInDirectory(
+        `${sep}pizza dir`,
+        jsonReaderStub,
+    );
     t.equal(config.name, 'big pizza co');
     t.equal(config.version, '0.0.0');
     t.equal(config.server, 'https://test');
@@ -154,7 +157,7 @@ test('name is pulled from package.json if not defined in eik.json', (t) => {
 });
 
 test('tokens are present', (t) => {
-    const config = configStore.findInDirectory('/pizza dir', (path) => {
+    const config = configStore.findInDirectory(`${sep}pizza dir`, (path) => {
         if (path.includes('eik.json')) return mockEikJSON();
         if (path.includes('.eikrc'))
             return { tokens: [['http://server', 'muffins']] };
@@ -173,7 +176,7 @@ test('invalid json error', (t) => {
     };
 
     try {
-        configStore.findInDirectory('/pizza dir', jsonReaderStub);
+        configStore.findInDirectory(`${sep}pizza dir`, jsonReaderStub);
     } catch (e) {
         t.match(e.message, /Unexpected token/);
     }
@@ -183,11 +186,11 @@ test('invalid json error', (t) => {
 test('no configuration present', (t) => {
     t.plan(1);
     try {
-        configStore.findInDirectory('/pizza dir', () => {});
+        configStore.findInDirectory(`${sep}pizza dir`, () => {});
     } catch (e) {
         t.equal(
             e.message,
-            "No package.json or eik.json file found in: '/pizza dir'",
+            `No package.json or eik.json file found in: '${sep}pizza dir'`,
         );
     }
     t.end();

--- a/test/helpers/resolve-files.test.js
+++ b/test/helpers/resolve-files.test.js
@@ -51,7 +51,7 @@ tap.test(
         );
         t.equal(
             absolute,
-            join(basePath, relative),
+            join(basePath, relative).replace(/\\/g, '/'),
             '.absolute should include .basePath and .relative',
         );
         t.match(
@@ -201,7 +201,7 @@ tap.test(
         );
         t.equal(
             absolute,
-            join(basePath, relative),
+            join(basePath, relative).replace(/\\/g, '/'),
             '.absolute should include .basePath and .relative',
         );
         t.match(

--- a/test/helpers/resolve-files.test.js
+++ b/test/helpers/resolve-files.test.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { join, basename, dirname } from 'node:path';
 import tap from 'tap';
 import resolveFiles from '../../lib/helpers/resolve-files.js';
+import { ensurePosix } from '../../lib/helpers/path-slashes.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -51,7 +52,7 @@ tap.test(
         );
         t.equal(
             absolute,
-            join(basePath, relative).replace(/\\/g, '/'),
+            ensurePosix(join(basePath, relative)),
             '.absolute should include .basePath and .relative',
         );
         t.match(
@@ -201,7 +202,7 @@ tap.test(
         );
         t.equal(
             absolute,
-            join(basePath, relative).replace(/\\/g, '/'),
+            ensurePosix(join(basePath, relative)),
             '.absolute should include .basePath and .relative',
         );
         t.match(

--- a/test/helpers/resolve-files.test.js
+++ b/test/helpers/resolve-files.test.js
@@ -220,8 +220,8 @@ tap.test(
 tap.test(
     'when source is an absolute file and cwd is a different directory entirely',
     async (t) => {
-        const cwd = await fs.mkdtempSync(
-            join(os.tmpdir(), basename(__filename)),
+        const cwd = fs.mkdtempSync(
+            join(os.tmpdir(), 'resolve-files-test-file'),
         );
         const resolved = await resolveFiles(
             { '/': join(fixturesPath, 'folder/client.js') },
@@ -243,8 +243,8 @@ tap.test(
 tap.test(
     'when source is an absolute folder with glob and cwd is a different directory entirely',
     async (t) => {
-        const cwd = await fs.mkdtempSync(
-            join(os.tmpdir(), basename(__filename)),
+        const cwd = fs.mkdtempSync(
+            join(os.tmpdir(), 'resolve-files-test-glob'),
         );
         const resolved = await resolveFiles(
             { '/': join(fixturesPath, 'folder/**/*') },


### PR DESCRIPTION
Windows paths threw a spanner in the works. This might not be the
optimal solution for outside modules, in which case I'm open to
changing the behavior to maintain win32 style paths on that OS.
The reasoning here is to keep in line with glob (which recommends
only using forward slashes in patterns) and the URLs which end up
on the Eik server (which, being HTTP URLs, use forward slash).

This should hopefully fix an issue Windows users have with the Eik
CLI not finding the files configured in eik.json