### PR TITLE
Add load exact method

### DIFF
--- a/lib/helpers/config-store.js
+++ b/lib/helpers/config-store.js
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 import os from 'node:os';
 import EikConfig from '../classes/eik-config.js';
 import MissingConfigError from '../classes/missing-config-error.js';
@@ -27,6 +27,31 @@ function readJSONFromDisk(path) {
 }
 
 export default {
+    /**
+     * Load the configuration from an exact path and return an EikConfig object
+     *
+     * @param {string} configFilePathname
+     * @param {function} loadJSONFromDisk
+     *
+     * @returns {EikConfig}
+     */
+    loadExact(configFilePathname, loadJSONFromDisk = readJSONFromDisk) {
+        const eikJSON = loadJSONFromDisk(configFilePathname);
+        if (!eikJSON) {
+            throw new MissingConfigError(dirname(configFilePathname));
+        }
+        let assets = eikJSON;
+        // detect package.json
+        if (eikJSON.eik) {
+            assets = {
+                name: eikJSON.name,
+                version: eikJSON.version,
+                ...eikJSON.eik,
+            };
+        }
+        const eikrc = loadJSONFromDisk(join(homedir, '.eikrc')) || {};
+        return new EikConfig(assets, eikrc.tokens, dirname(configFilePathname));
+    },
     /**
      * Tries to find the configuration for eik in the provided directory.
      *

--- a/lib/helpers/config-store.js
+++ b/lib/helpers/config-store.js
@@ -35,7 +35,7 @@ export default {
      *
      * @returns {EikConfig}
      */
-    loadExact(configFilePathname, loadJSONFromDisk = readJSONFromDisk) {
+    loadFromPath(configFilePathname, loadJSONFromDisk = readJSONFromDisk) {
         const eikJSON = loadJSONFromDisk(configFilePathname);
         if (!eikJSON) {
             throw new MissingConfigError(dirname(configFilePathname));

--- a/lib/helpers/get-defaults.js
+++ b/lib/helpers/get-defaults.js
@@ -1,23 +1,30 @@
 // @ts-check
+import fs from 'node:fs';
 import configStore from './config-store.js';
 import EikConfig from '../classes/eik-config.js';
 /**
  * Sets up and returns an object containing a set of default values for the app context.
  * Default values are fetched from the app's eik.json or package.json file as well as from .eikrc, if present in the users home directory.
  *
- * @param {string} cwd The current working directory
+ * @param {string} directoryOrFilepath The directory to search for eik.json or package.json or an exact path to an eik.json or package.json file
  *
  * @returns {import("../classes/eik-config")} EikConfig
  */
-export default function getDefaults(cwd) {
+export default function getDefaults(directoryOrFilepath) {
     try {
-        // @ts-ignore
-        return configStore.findInDirectory(cwd);
-    } catch (e) {
-        // @ts-ignore
+        const stats = fs.statSync(directoryOrFilepath);
+        if (stats.isDirectory()) {
+            // @ts-expect-error
+            return configStore.findInDirectory(directoryOrFilepath);
+        } else {
+            // @ts-expect-error
+            return configStore.loadExact(directoryOrFilepath);
+        }
+    } catch (error) {
+        const e = /** @type {Error} */ (error);
         if (e.constructor.name === 'MissingConfigError') {
-            // @ts-ignore
-            return new EikConfig(null, [], cwd);
+            // @ts-expect-error
+            return new EikConfig(null, [], directoryOrFilepath);
         }
         throw e;
     }

--- a/lib/helpers/get-defaults.js
+++ b/lib/helpers/get-defaults.js
@@ -1,5 +1,6 @@
 // @ts-check
 import fs from 'node:fs';
+import path from 'node:path';
 import configStore from './config-store.js';
 import EikConfig from '../classes/eik-config.js';
 /**
@@ -23,8 +24,14 @@ export default function getDefaults(directoryOrFilepath) {
     } catch (error) {
         const e = /** @type {Error} */ (error);
         if (e.constructor.name === 'MissingConfigError') {
+            // assume directory
+            let cwd = directoryOrFilepath;
+            // detect exact file and get its directory
+            if (path.extname(directoryOrFilepath)) {
+                cwd = path.dirname(directoryOrFilepath);
+            }
             // @ts-expect-error
-            return new EikConfig(null, [], directoryOrFilepath);
+            return new EikConfig(null, [], cwd);
         }
         throw e;
     }

--- a/test/helpers/config-store.test.js
+++ b/test/helpers/config-store.test.js
@@ -66,7 +66,7 @@ test('loads from eik.json', (t) => {
 });
 
 test('loads eik.json from an exact path', (t) => {
-    const config = configStore.loadExact(
+    const config = configStore.loadFromPath(
         '/exact/pizza/dir/eik.json',
         (path) => {
             if (path.includes('package.json') || path.includes('.eikrc'))

--- a/test/helpers/config-store.test.js
+++ b/test/helpers/config-store.test.js
@@ -65,6 +65,20 @@ test('loads from eik.json', (t) => {
     t.end();
 });
 
+test('loads eik.json from an exact path', (t) => {
+    const config = configStore.loadExact(
+        '/exact/pizza/dir/eik.json',
+        (path) => {
+            if (path.includes('package.json') || path.includes('.eikrc'))
+                return null;
+            t.match(path, '/exact/pizza/dir/eik.json');
+            return mockEikJSON();
+        },
+    );
+    t.equal(config.name, 'magarita');
+    t.end();
+});
+
 test('loads from eik.json - invalid config', (t) => {
     try {
         configStore.findInDirectory('/pizza dir', (path) => {


### PR DESCRIPTION
Makes it possible to pass an exact path to a config file (either package.json or eik.json) to the get-defaults method used in the cli commands. Non breaking backwards compatible change.

Part of the work needed to solve https://github.com/eik-lib/cli/issues/553