### PR TITLE
fix: use the correct upstream schema link for ajv 

### DIFF
--- a/eikjson.d.ts
+++ b/eikjson.d.ts
@@ -6,6 +6,7 @@
  */
 
 export interface EikjsonSchema {
+  $schema?: string;
   /**
    * The URL address of the Eik server where packages are published to.
    */

--- a/lib/schemas/eikjson.schema.json
+++ b/lib/schemas/eikjson.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "type": "object",
   "properties": {

--- a/lib/schemas/eikjson.schema.json
+++ b/lib/schemas/eikjson.schema.json
@@ -3,6 +3,10 @@
   "additionalProperties": false,
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
     "server": {
       "description": "The URL address of the Eik server where packages are published to.",
       "type": "string",

--- a/lib/schemas/validate.js
+++ b/lib/schemas/validate.js
@@ -9,10 +9,7 @@ const createValidator = (schema, ajvOptions) => {
     const ajv = new Ajv(ajvOptions);
     // @ts-ignore
     formats(ajv); // Needed to support "uri"
-    const validate = ajv.compile({
-        $schema: 'http://json-schema.org/schema#',
-        ...schema,
-    });
+    const validate = ajv.compile(schema);
 
     return (data) => {
         const cloned = JSON.parse(JSON.stringify(data));


### PR DESCRIPTION
VS Code complained the schema couldn't be found.

![](https://github.com/user-attachments/assets/cda23729-733c-4b9f-aedf-d39749b2acd7)
