### PR TITLE
fix: add extra validation to mitigate open redirect vuln

### DIFF
--- a/lib/validators/index.js
+++ b/lib/validators/index.js
@@ -52,9 +52,15 @@ export const type = (value) => {
     throw new Error(`Parameter "type" is not valid - Value: ${value}`);
 };
 
-// TODO; https://github.com/asset-pipe/core/issues/12
+const pathTraversalPattern = /\.\./;
 // @ts-ignore
-export const extra = (value) => value;
+export const extra = (value) => {
+    console.log(value, !pathTraversalPattern.test(value));
+    if (!pathTraversalPattern.test(value)) {
+        return value;
+    }
+    throw new Error(`Parameter "extra" is not valid - Value: ${value}`);
+};
 
 // @ts-ignore
 export const semverType = (value) => {

--- a/test/validators/index.test.js
+++ b/test/validators/index.test.js
@@ -206,6 +206,13 @@ test('.extra() - valid values - should return value', (t) => {
     t.end();
 });
 
+test('.extra() - path traversal - should throw', (t) => {
+    t.throws(() => {
+        validators.extra('../test');
+    }, new Error('Parameter "extra" is not valid'));
+    t.end();
+});
+
 //
 // .semverType()
 //


### PR DESCRIPTION
Lacking validation on the `extra` parameter leads to an [open redirect vulnerability](https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html).

For example: [https://assets.finn.no/pkg/@warp-ds/css/v1/%2f..%2f..%2f..%2f..%2f%5C%5Cvg.no](https://assets.finn.no/pkg/@warp-ds/css/v1/%2f..%2f..%2f..%2f..%2f%5C%5Cvg.no), will in most browsers redirect to vg.no.