### PR TITLE
feat: add support for Eik image type

### DIFF
--- a/eikjson.d.ts
+++ b/eikjson.d.ts
@@ -20,9 +20,9 @@ export interface EikjsonSchema {
    */
   version: string;
   /**
-   * The type of the Eik package. Must be one of 'package', 'npm' or 'map'. Setting this value changes the URL publish namespace between '/pkg' (default), '/npm' and '/map', use 'npm' when publishing NPM packages. Use 'map' when publishing import maps.
+   * The type of the Eik package. Must be one of 'package', 'npm', 'map' or 'image'. Setting this value changes the URL publish namespace between '/pkg' (default), '/npm', '/map' and '/img', use 'npm' when publishing NPM packages. Use 'image' when publishing images. Use 'map' when publishing import maps.
    */
-  type?: "package" | "npm" | "map";
+  type?: "package" | "npm" | "map" | "image";
   /**
    * File mapping definition for the package. Keys represent files or paths to be created on the Eik Server. Values represent paths to local files to be published.
    */

--- a/lib/helpers/type-slug.js
+++ b/lib/helpers/type-slug.js
@@ -5,5 +5,6 @@
  */
 export default (type) => {
     if (type === 'package') return 'pkg';
+    if (type === 'image') return 'img';
     return type;
 };

--- a/lib/helpers/type-title.js
+++ b/lib/helpers/type-title.js
@@ -6,5 +6,6 @@
 export default (type) => {
     if (type === 'package') return 'PACKAGE';
     if (type === 'npm') return 'NPM';
+    if (type === 'image') return 'IMAGE';
     return 'MAP';
 };

--- a/lib/schemas/assert.js
+++ b/lib/schemas/assert.js
@@ -20,7 +20,7 @@ const assert = (validate, message) => (value) => {
             .map((err) => {
                 let msg = err.message;
                 if (err.params && err.params.allowedValues) {
-                    msg += ` ("${err.params.allowedValues.join('", ')}")`;
+                    msg += ` ("${err.params.allowedValues.join('", "')}")`;
                 }
                 return msg;
             })

--- a/lib/schemas/eikjson.schema.json
+++ b/lib/schemas/eikjson.schema.json
@@ -24,9 +24,9 @@
       "minLength": 1
     },
     "type": {
-      "description": "The type of the Eik package. Must be one of 'package', 'npm' or 'map'. Setting this value changes the URL publish namespace between '/pkg' (default), '/npm' and '/map', use 'npm' when publishing NPM packages. Use 'map' when publishing import maps.",
+      "description": "The type of the Eik package. Must be one of 'package', 'npm', 'map' or 'image'. Setting this value changes the URL publish namespace between '/pkg' (default), '/npm', '/map' and '/img', use 'npm' when publishing NPM packages. Use 'image' when publishing images. Use 'map' when publishing import maps.",
       "type": "string",
-      "enum": ["package", "npm", "map"],
+      "enum": ["package", "npm", "map", "image"],
       "default": "package"
     },
     "files": {

--- a/lib/validators/index.js
+++ b/lib/validators/index.js
@@ -46,7 +46,12 @@ export const alias = (value) => {
 
 // @ts-ignore
 export const type = (value) => {
-    if (value === 'pkg' || value === 'map' || value === 'npm' || value === 'img') {
+    if (
+        value === 'pkg' ||
+        value === 'map' ||
+        value === 'npm' ||
+        value === 'img'
+    ) {
         return value;
     }
     throw new Error(`Parameter "type" is not valid - Value: ${value}`);

--- a/lib/validators/index.js
+++ b/lib/validators/index.js
@@ -46,7 +46,7 @@ export const alias = (value) => {
 
 // @ts-ignore
 export const type = (value) => {
-    if (value === 'pkg' || value === 'map' || value === 'npm') {
+    if (value === 'pkg' || value === 'map' || value === 'npm' || value === 'img') {
         return value;
     }
     throw new Error(`Parameter "type" is not valid - Value: ${value}`);

--- a/test/schemas/assert.test.js
+++ b/test/schemas/assert.test.js
@@ -94,7 +94,7 @@ test('assert type: invalid', (t) => {
     } catch (err) {
         t.equal(
             err.message,
-            'Parameter "type" is not valid: must be equal to one of the allowed values ("package", npm", map")',
+            'Parameter "type" is not valid: must be equal to one of the allowed values ("package", "npm", "map", "image")',
         );
     }
     t.end();


### PR DESCRIPTION
Step 1 in adding a new namespace.

After this, step 2 is a minor update to @eik/core and step 3 is then adding routes to @eik/service. In that order due to:

```mermaid
graph TD;
  eik/service-->eik/core;
  eik/core-->eik/common;
```