### PR TITLE
ci: Fix release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 26
+          node-version: 24
 
       - run: npm clean-install
 


### PR DESCRIPTION
Release erroring are due to node 26 and semantic compat issues. Pin publishing to node 24.